### PR TITLE
Ansi colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ Changelog
   A YAML file located at `~/.vgrep/config.yaml` is recognized as configuration
   file for colors and other settings. The default config file can be produced
   using `vgrep --dump-default-config > ~/.vgrep/config.yaml`.
+* Added support for colorized input
+  ([ANSI CSI/SGR escape codes](https://en.wikipedia.org/wiki/ANSI_escape_code#graphics)).
+  `vgrep` can now be used together wit `grep --color=always` (and `git grep
+  --color=always`), which is now enabled by default when using `vgrep` as
+  drop-in replacement for `grep`.
 
 
 ## v0.1.4.1

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -197,8 +197,8 @@ loadSelectedFileToPager = do
             then readLinesFrom selectedFile
             else use inputLines
         displayContent <- expandForDisplay fileContent
-        highlightLineNumbers <- use (results . currentFileResultLineNumbers)
-        zoom pager (replaceBufferContents displayContent highlightLineNumbers)
+        highlightedLines <- use (results . currentFileResults)
+        zoom pager (replaceBufferContents displayContent highlightedLines)
         moveToSelectedLineNumber
         zoom widgetState (splitView FocusRight (1 % 3))
   where

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -134,12 +134,11 @@ eventHandler = \case
         :: MonadIO m
         => Text
         -> Next (VgrepT AppState m Redraw)
-    handleFeedResult line = Continue $ do
-        case parseLine line of
-            Just l  -> do
-                l' <- traverseOf (lineReference . lineText) expandFormattedLine l
-                zoom results (feedResult l')
-            Nothing -> pure Unchanged
+    handleFeedResult line = Continue $ case parseLine line of
+        Just l  -> do
+            l' <- traverseOf (lineReference . lineText) expandFormattedLine l
+            zoom results (feedResult l')
+        Nothing -> pure Unchanged
     handleFeedInput line = Continue $ do
         expandedLine <- expandLineForDisplay line
         modifying inputLines (|> expandedLine)

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -135,9 +135,10 @@ eventHandler = \case
         => Text
         -> Next (VgrepT AppState m Redraw)
     handleFeedResult line = Continue $ do
-        expandedLine <- expandLineForDisplay line
-        case parseLine expandedLine of
-            Just l  -> zoom results (feedResult l)
+        case parseLine line of
+            Just l  -> do
+                l' <- traverseOf (lineReference . lineText) expandFormattedLine l
+                zoom results (feedResult l')
             Nothing -> pure Unchanged
     handleFeedInput line = Continue $ do
         expandedLine <- expandLineForDisplay line
@@ -190,10 +191,10 @@ loadSelectedFileToPager :: MonadIO m => VgrepT AppState m Redraw
 loadSelectedFileToPager = do
     maybeFileName <- uses (results . currentFileName)
                           (fmap T.unpack)
-    whenJust maybeFileName $ \fileName -> do
-        fileExists <- liftIO (doesFileExist fileName)
+    whenJust maybeFileName $ \selectedFile -> do
+        fileExists <- liftIO (doesFileExist selectedFile)
         fileContent <- if fileExists
-            then readLinesFrom fileName
+            then readLinesFrom selectedFile
             else use inputLines
         displayContent <- expandForDisplay fileContent
         highlightLineNumbers <- use (results . currentFileResultLineNumbers)
@@ -201,8 +202,8 @@ loadSelectedFileToPager = do
         moveToSelectedLineNumber
         zoom widgetState (splitView FocusRight (1 % 3))
   where
-    readLinesFrom file = liftIO $ do
-        content <- TL.readFile file
+    readLinesFrom f = liftIO $ do
+        content <- TL.readFile f
         pure (fileLines content)
     fileLines = S.fromList . map TL.toStrict . TL.lines
 
@@ -217,12 +218,12 @@ whenJust item action = maybe (pure mempty) action item
 
 invokeEditor :: AppState -> Next (VgrepT AppState m Redraw)
 invokeEditor state = case views (results . currentFileName) (fmap T.unpack) state of
-    Just file -> Interrupt $ Suspend $ \environment -> do
+    Just selectedFile -> Interrupt $ Suspend $ \environment -> do
         let configuredEditor = view (config . editor) environment
-            lineNumber = views (results . currentLineNumber) (fromMaybe 0) state
-        liftIO $ doesFileExist file >>= \case
-            True  -> exec configuredEditor ['+' : show lineNumber, file]
-            False -> hPutStrLn stderr ("File not found: " ++ show file)
+            selectedLineNumber = views (results . currentLineNumber) (fromMaybe 0) state
+        liftIO $ doesFileExist selectedFile >>= \case
+            True  -> exec configuredEditor ['+' : show selectedLineNumber, selectedFile]
+            False -> hPutStrLn stderr ("File not found: " ++ show selectedFile)
     Nothing -> Skip
 
 exec :: MonadIO io => FilePath -> [String] -> io ()

--- a/src/Vgrep/Ansi.hs
+++ b/src/Vgrep/Ansi.hs
@@ -28,15 +28,18 @@ import Vgrep.Ansi.Type
 
 
 -- | Converts ANSI formatted text to an 'Vty.Image'. Nested formattings are
--- combined with 'combineStyles'.
-renderAnsi :: Formatted Vty.Attr -> Vty.Image
-renderAnsi = go mempty
-  where
-    go attr = \case
-        Empty            -> Vty.emptyImage
-        Text _ t         -> Vty.text' attr t
-        Format _ attr' t -> go (combineStyles attr attr') t
-        Cat _ ts         -> Vty.horizCat (map (go attr) ts)
+-- combined with 'combineStyles'. The given 'Vty.Attr' is used as style for the
+-- root of the 'Formatted' tree.
+--
+-- >>> renderAnsi Vty.defAttr (bare "Text")
+-- HorizText "Text"@(Attr {attrStyle = Default, attrForeColor = Default, attrBackColor = Default},4,4)
+--
+renderAnsi :: Vty.Attr -> Formatted Vty.Attr -> Vty.Image
+renderAnsi attr = \case
+    Empty            -> Vty.emptyImage
+    Text _ t         -> Vty.text' attr t
+    Format _ attr' t -> renderAnsi (combineStyles attr attr') t
+    Cat _ ts         -> Vty.horizCat (map (renderAnsi attr) ts)
 
 -- | Strips away all formattings to plain 'Text'.
 stripAnsi :: Formatted a -> Text

--- a/src/Vgrep/Ansi.hs
+++ b/src/Vgrep/Ansi.hs
@@ -25,17 +25,17 @@ renderAnsi :: Formatted Vty.Attr -> Vty.Image
 renderAnsi = go mempty
   where
     go attr = \case
-        Empty          -> Vty.emptyImage
-        Text t         -> Vty.text' attr t
-        Format attr' t -> go (combine attr attr') t
-        Cat ts         -> Vty.horizCat (map (go attr) ts)
+        Empty            -> Vty.emptyImage
+        Text _ t         -> Vty.text' attr t
+        Format _ attr' t -> go (combine attr attr') t
+        Cat _ ts         -> Vty.horizCat (map (go attr) ts)
 
 stripAnsi :: Formatted a -> Text
 stripAnsi = \case
-    Empty      -> mempty
-    Text t     -> t
-    Format _ t -> stripAnsi t
-    Cat ts     -> foldMap stripAnsi ts
+    Empty        -> mempty
+    Text _ t     -> t
+    Format _ _ t -> stripAnsi t
+    Cat _ ts     -> foldMap stripAnsi ts
 
 -- | Combines two 'Vty.Attr's. This differs from 'mappend' from the 'Monoid'
 -- instance of 'Vty.Attr' in that 'Vty.Style's are combined rather than

--- a/src/Vgrep/Ansi.hs
+++ b/src/Vgrep/Ansi.hs
@@ -11,6 +11,9 @@ module Vgrep.Ansi (
   -- ** Modifying text nodes
   , mapText
   , mapTextWithPos
+  , takeFormatted
+  , dropFormatted
+  , padFormatted
 
   -- * Converting ANSI formatted text
   , renderAnsi

--- a/src/Vgrep/Ansi.hs
+++ b/src/Vgrep/Ansi.hs
@@ -1,0 +1,37 @@
+module Vgrep.Ansi
+  ( renderAnsi
+  , stripAnsi
+  , parseAnsi
+  , Vty.Attr ()
+  , module Vgrep.Ansi.Types
+  )where
+
+import           Data.Bits    ((.|.))
+import           Data.Text    (Text)
+import qualified Graphics.Vty as Vty
+
+import Vgrep.Ansi.Parser
+import Vgrep.Ansi.Types
+
+
+renderAnsi :: Formatted Vty.Attr -> Vty.Image
+renderAnsi = \case
+    Node attr ts -> Vty.horizCat (fmap (renderAnsi . fmap (combine attr)) ts)
+    Leaf attr t  -> Vty.text' attr t
+
+stripAnsi :: Formatted a -> Text
+stripAnsi = \case
+    Node _ ts -> foldMap stripAnsi ts
+    Leaf _ t  -> t
+
+-- | Combines two 'Vty.Attr's. This differs from 'mappend' from the 'Monoid'
+-- instance of 'Vty.Attr' in that 'Vty.Style's are combined rather than
+-- overwritten.
+combine :: Vty.Attr -> Vty.Attr -> Vty.Attr
+combine l r = Vty.Attr
+    { Vty.attrStyle = case (Vty.attrStyle l, Vty.attrStyle r) of
+        (Vty.SetTo l', Vty.SetTo r') -> Vty.SetTo (l' .|. r')
+        (l', r')                     -> mappend l' r'
+    , Vty.attrForeColor = mappend (Vty.attrForeColor l) (Vty.attrForeColor r)
+    , Vty.attrBackColor = mappend (Vty.attrBackColor l) (Vty.attrBackColor r)
+    }

--- a/src/Vgrep/Ansi.hs
+++ b/src/Vgrep/Ansi.hs
@@ -21,6 +21,7 @@ module Vgrep.Ansi (
   )where
 
 import           Data.Bits    ((.|.))
+import           Data.Monoid  ((<>))
 import           Data.Text    (Text)
 import qualified Graphics.Vty as Vty
 
@@ -56,7 +57,7 @@ combineStyles :: Vty.Attr -> Vty.Attr -> Vty.Attr
 combineStyles l r = Vty.Attr
     { Vty.attrStyle = case (Vty.attrStyle l, Vty.attrStyle r) of
         (Vty.SetTo l', Vty.SetTo r') -> Vty.SetTo (l' .|. r')
-        (l', r')                     -> mappend l' r'
-    , Vty.attrForeColor = mappend (Vty.attrForeColor l) (Vty.attrForeColor r)
-    , Vty.attrBackColor = mappend (Vty.attrBackColor l) (Vty.attrBackColor r)
+        (l', r')                     -> l' <> r'
+    , Vty.attrForeColor = Vty.attrForeColor l <> Vty.attrForeColor r
+    , Vty.attrBackColor = Vty.attrBackColor l <> Vty.attrBackColor r
     }

--- a/src/Vgrep/Ansi.hs
+++ b/src/Vgrep/Ansi.hs
@@ -3,7 +3,7 @@ module Vgrep.Ansi (
   -- * ANSI formatted text
     Formatted ()
   -- ** Smart constructors
-  , empty
+  , emptyFormatted
   , bare
   , format
   , cat

--- a/src/Vgrep/Ansi.hs
+++ b/src/Vgrep/Ansi.hs
@@ -1,7 +1,8 @@
 -- | Utilities for printing ANSI formatted text.
 module Vgrep.Ansi (
   -- * ANSI formatted text
-    Formatted ()
+    AnsiFormatted
+  , Formatted ()
   -- ** Smart constructors
   , emptyFormatted
   , bare
@@ -14,18 +15,13 @@ module Vgrep.Ansi (
   -- * Converting ANSI formatted text
   , renderAnsi
   , stripAnsi
+  ) where
 
-  -- * Attributes
-  , Vty.Attr ()
-  , combineStyles
-  )where
-
-import           Data.Bits    ((.|.))
-import           Data.Monoid  ((<>))
 import           Data.Text    (Text)
 import qualified Graphics.Vty as Vty
 
 import Vgrep.Ansi.Type
+import Vgrep.Ansi.Vty.Attributes
 
 
 -- | Converts ANSI formatted text to an 'Vty.Image'. Nested formattings are
@@ -35,7 +31,7 @@ import Vgrep.Ansi.Type
 -- >>> renderAnsi Vty.defAttr (bare "Text")
 -- HorizText "Text"@(Attr {attrStyle = Default, attrForeColor = Default, attrBackColor = Default},4,4)
 --
-renderAnsi :: Vty.Attr -> Formatted Vty.Attr -> Vty.Image
+renderAnsi :: Attr -> AnsiFormatted -> Vty.Image
 renderAnsi attr = \case
     Empty            -> Vty.emptyImage
     Text _ t         -> Vty.text' attr t
@@ -49,15 +45,3 @@ stripAnsi = \case
     Text _ t     -> t
     Format _ _ t -> stripAnsi t
     Cat _ ts     -> foldMap stripAnsi ts
-
--- | Combines two 'Vty.Attr's. This differs from 'mappend' from the 'Monoid'
--- instance of 'Vty.Attr' in that 'Vty.Style's are combined rather than
--- overwritten.
-combineStyles :: Vty.Attr -> Vty.Attr -> Vty.Attr
-combineStyles l r = Vty.Attr
-    { Vty.attrStyle = case (Vty.attrStyle l, Vty.attrStyle r) of
-        (Vty.SetTo l', Vty.SetTo r') -> Vty.SetTo (l' .|. r')
-        (l', r')                     -> l' <> r'
-    , Vty.attrForeColor = Vty.attrForeColor l <> Vty.attrForeColor r
-    , Vty.attrBackColor = Vty.attrBackColor l <> Vty.attrBackColor r
-    }

--- a/src/Vgrep/Ansi.hs
+++ b/src/Vgrep/Ansi.hs
@@ -1,36 +1,44 @@
-module Vgrep.Ansi
-  ( Formatted ()
+-- | Utilities for printing ANSI formatted text.
+module Vgrep.Ansi (
+  -- * ANSI formatted text
+    Formatted ()
+  -- ** Smart constructors
   , empty
   , bare
   , format
   , cat
+  -- ** Modifying text nodes
   , mapText
   , mapTextWithPos
 
+  -- * Converting ANSI formatted text
   , renderAnsi
   , stripAnsi
-  , parseAnsi
 
+  -- * Attributes
   , Vty.Attr ()
+  , combineStyles
   )where
 
 import           Data.Bits    ((.|.))
 import           Data.Text    (Text)
 import qualified Graphics.Vty as Vty
 
-import Vgrep.Ansi.Parser
 import Vgrep.Ansi.Type
 
 
+-- | Converts ANSI formatted text to an 'Vty.Image'. Nested formattings are
+-- combined with 'combineStyles'.
 renderAnsi :: Formatted Vty.Attr -> Vty.Image
 renderAnsi = go mempty
   where
     go attr = \case
         Empty            -> Vty.emptyImage
         Text _ t         -> Vty.text' attr t
-        Format _ attr' t -> go (combine attr attr') t
+        Format _ attr' t -> go (combineStyles attr attr') t
         Cat _ ts         -> Vty.horizCat (map (go attr) ts)
 
+-- | Strips away all formattings to plain 'Text'.
 stripAnsi :: Formatted a -> Text
 stripAnsi = \case
     Empty        -> mempty
@@ -41,8 +49,8 @@ stripAnsi = \case
 -- | Combines two 'Vty.Attr's. This differs from 'mappend' from the 'Monoid'
 -- instance of 'Vty.Attr' in that 'Vty.Style's are combined rather than
 -- overwritten.
-combine :: Vty.Attr -> Vty.Attr -> Vty.Attr
-combine l r = Vty.Attr
+combineStyles :: Vty.Attr -> Vty.Attr -> Vty.Attr
+combineStyles l r = Vty.Attr
     { Vty.attrStyle = case (Vty.attrStyle l, Vty.attrStyle r) of
         (Vty.SetTo l', Vty.SetTo r') -> Vty.SetTo (l' .|. r')
         (l', r')                     -> mappend l' r'

--- a/src/Vgrep/Ansi.hs
+++ b/src/Vgrep/Ansi.hs
@@ -1,9 +1,16 @@
 module Vgrep.Ansi
-  ( renderAnsi
+  ( Formatted ()
+  , empty
+  , bare
+  , format
+  , cat
+  , mapText
+
+  , renderAnsi
   , stripAnsi
   , parseAnsi
+
   , Vty.Attr ()
-  , module Vgrep.Ansi.Type
   )where
 
 import           Data.Bits    ((.|.))

--- a/src/Vgrep/Ansi.hs
+++ b/src/Vgrep/Ansi.hs
@@ -3,7 +3,7 @@ module Vgrep.Ansi
   , stripAnsi
   , parseAnsi
   , Vty.Attr ()
-  , module Vgrep.Ansi.Types
+  , module Vgrep.Ansi.Type
   )where
 
 import           Data.Bits    ((.|.))
@@ -11,7 +11,7 @@ import           Data.Text    (Text)
 import qualified Graphics.Vty as Vty
 
 import Vgrep.Ansi.Parser
-import Vgrep.Ansi.Types
+import Vgrep.Ansi.Type
 
 
 renderAnsi :: Formatted Vty.Attr -> Vty.Image

--- a/src/Vgrep/Ansi.hs
+++ b/src/Vgrep/Ansi.hs
@@ -5,6 +5,7 @@ module Vgrep.Ansi
   , format
   , cat
   , mapText
+  , mapTextWithPos
 
   , renderAnsi
   , stripAnsi

--- a/src/Vgrep/Ansi/Parser.hs
+++ b/src/Vgrep/Ansi/Parser.hs
@@ -3,7 +3,6 @@ module Vgrep.Ansi.Parser
   ( parseAnsi
   , ansiFormatted
   , attrChange
-  , module Vgrep.Ansi.Type
   ) where
 
 
@@ -33,11 +32,11 @@ ansiFormatted = go mempty
         let attr' = ac attr
         t  <- rawText
         rest <- go attr'
-        pure (Format attr' (Text t) <> rest)
+        pure (format attr' (bare t) <> rest)
     unformattedText attr = do
         t <- rawText
         rest <- go attr
-        pure (Format attr (Text t) <> rest)
+        pure (format attr (bare t) <> rest)
     rawText = takeTill (== '\ESC') <|> takeText
 
 

--- a/src/Vgrep/Ansi/Parser.hs
+++ b/src/Vgrep/Ansi/Parser.hs
@@ -3,7 +3,7 @@ module Vgrep.Ansi.Parser
   ( parseAnsi
   , ansiFormatted
   , attrChange
-  , module Vgrep.Ansi.Types
+  , module Vgrep.Ansi.Type
   ) where
 
 
@@ -15,7 +15,7 @@ import           Data.Text               (Text)
 import           Graphics.Vty.Attributes (Attr)
 import qualified Graphics.Vty.Attributes as Vty
 
-import Vgrep.Ansi.Types
+import Vgrep.Ansi.Type
 
 
 parseAnsi :: Text -> Formatted Attr

--- a/src/Vgrep/Ansi/Parser.hs
+++ b/src/Vgrep/Ansi/Parser.hs
@@ -58,15 +58,22 @@ parseAnsi = either error id . parseOnly ansiFormatted
 ansiFormatted :: Parser (Formatted Attr)
 ansiFormatted = go mempty
   where
+    go :: Attr -> Parser (Formatted Attr)
     go attr = endOfInput *> pure mempty
           <|> formattedText attr
+
+    formattedText :: Attr -> Parser (Formatted Attr)
     formattedText attr = do
         acs <- many attrChange
         let attr' = foldr ($) attr acs
         t <- rawText
         rest <- go attr'
         pure (format attr' (bare t) <> rest)
+
+    rawText :: Parser Text
     rawText = atLeastOneTill (== '\ESC') <|> endOfInput *> pure ""
+
+    atLeastOneTill :: (Char -> Bool) -> Parser Text
     atLeastOneTill = liftA2 T.cons anyChar . takeTill
 
 

--- a/src/Vgrep/Ansi/Parser.hs
+++ b/src/Vgrep/Ansi/Parser.hs
@@ -1,0 +1,109 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Vgrep.Ansi.Parser
+  ( parseAnsi
+  , ansiFormatted
+  , attrChange
+  , module Vgrep.Ansi.Types
+  ) where
+
+
+import           Control.Applicative
+import           Data.Attoparsec.Text
+import           Data.Bits
+import           Data.Monoid
+import           Data.Text               (Text)
+import           Graphics.Vty.Attributes (Attr)
+import qualified Graphics.Vty.Attributes as Vty
+
+import Vgrep.Ansi.Types
+
+
+parseAnsi :: Text -> Formatted Attr
+parseAnsi = either error id . parseOnly ansiFormatted
+
+
+ansiFormatted :: Parser (Formatted Attr)
+ansiFormatted = go mempty
+  where
+    go attr = endOfInput *> pure mempty
+          <|> formattedText attr
+          <|> unformattedText attr
+    formattedText attr = do
+        ac <- attrChange
+        t  <- rawText
+        rest <- go (ac attr)
+        pure (Leaf (ac attr) t <> rest)
+    unformattedText attr = do
+        t <- rawText
+        rest <- go (attr)
+        pure (Leaf attr t <> rest)
+    rawText = takeTill (== '\ESC') <|> takeText
+
+
+attrChange :: Parser (Attr -> Attr)
+attrChange = fmap csiToAttrChange csi
+
+csiEscape :: Parser Text
+csiEscape = "\ESC["
+
+csi :: Parser Csi
+csi = csiEscape >> liftA2 Csi (decimal `sepBy` char ';') anyChar
+
+data Csi = Csi [Int] Char
+
+csiToAttrChange :: Csi -> (Attr -> Attr)
+csiToAttrChange = \case
+    Csi [] 'm' -> const mempty
+    Csi is 'm' -> foldMap attrChangeFromCode is
+    _otherwise -> id
+
+attrChangeFromCode :: Int -> (Attr -> Attr)
+attrChangeFromCode = \case
+    0  -> const mempty
+    1  -> withStyle Vty.bold
+    3  -> withStyle Vty.standout
+    4  -> withStyle Vty.underline
+    5  -> withStyle Vty.blink
+    6  -> withStyle Vty.blink
+    7  -> withStyle Vty.reverseVideo
+    21 -> withoutStyle Vty.bold
+    22 -> withoutStyle Vty.bold
+    23 -> withoutStyle Vty.standout
+    24 -> withoutStyle Vty.underline
+    25 -> withoutStyle Vty.blink
+    27 -> withoutStyle Vty.reverseVideo
+    i | i >= 30  && i <= 37   -> withForeColor (rawColor (i - 30))
+      | i >= 40  && i <= 47   -> withBackColor (rawColor (i - 40))
+      | i >= 90  && i <= 97   -> withForeColor (rawBrightColor (i - 90))
+      | i >= 100 && i <= 107  -> withBackColor (rawBrightColor (i - 100))
+    39 -> resetForeColor
+    49 -> resetBackColor
+    _  -> id
+  where
+    rawColor = \case
+        0 -> Vty.black
+        1 -> Vty.red
+        2 -> Vty.green
+        3 -> Vty.yellow
+        4 -> Vty.blue
+        5 -> Vty.magenta
+        6 -> Vty.cyan
+        _ -> Vty.white
+    rawBrightColor = \case
+        0 -> Vty.brightBlack
+        1 -> Vty.brightRed
+        2 -> Vty.brightGreen
+        3 -> Vty.brightYellow
+        4 -> Vty.brightBlue
+        5 -> Vty.brightMagenta
+        6 -> Vty.brightCyan
+        _ -> Vty.brightWhite
+    withStyle = flip Vty.withStyle
+    withForeColor = flip Vty.withForeColor
+    withBackColor = flip Vty.withBackColor
+    withoutStyle style attr = case Vty.attrStyle attr of
+        Vty.SetTo oldStyle | oldStyle `Vty.hasStyle` style
+                   -> attr { Vty.attrStyle = Vty.SetTo (oldStyle .&. complement style) }
+        _otherwise -> attr
+    resetForeColor attr = attr { Vty.attrForeColor = Vty.KeepCurrent }
+    resetBackColor attr = attr { Vty.attrBackColor = Vty.KeepCurrent }

--- a/src/Vgrep/Ansi/Parser.hs
+++ b/src/Vgrep/Ansi/Parser.hs
@@ -60,17 +60,12 @@ ansiFormatted = go mempty
   where
     go attr = endOfInput *> pure mempty
           <|> formattedText attr
-          <|> unformattedText attr
     formattedText attr = do
-        acs <- some attrChange
+        acs <- many attrChange
         let attr' = foldr ($) attr acs
         t <- rawText
         rest <- go attr'
         pure (format attr' (bare t) <> rest)
-    unformattedText attr = do
-        t <- rawText
-        rest <- go attr
-        pure (bare t <> rest)
     rawText = atLeastOneTill (== '\ESC') <|> endOfInput *> pure ""
     atLeastOneTill = liftA2 T.cons anyChar . takeTill
 

--- a/src/Vgrep/Ansi/Parser.hs
+++ b/src/Vgrep/Ansi/Parser.hs
@@ -42,7 +42,7 @@ Non-CSI sequences are not parsed, but included in the output:
 Cat 17 [Text 14 "\ESC]710;font\afoo",Format 3 (Attr {attrStyle = KeepCurrent, attrForeColor = SetTo (ISOColor 1), attrBackColor = KeepCurrent}) (Text 3 "bar")]
 
 -}
-parseAnsi :: Text -> Formatted Attr
+parseAnsi :: Text -> AnsiFormatted
 parseAnsi = either error id . parseOnly ansiFormatted
 -- The use of 'error' ↑ is safe: 'ansiFormatted' does not fail.
 
@@ -55,14 +55,14 @@ parseAnsi = either error id . parseOnly ansiFormatted
 --
 -- This parser does not fail, it will rather consume and return the remaining
 -- input as unformatted text.
-ansiFormatted :: Parser (Formatted Attr)
+ansiFormatted :: Parser AnsiFormatted
 ansiFormatted = go mempty
   where
-    go :: Attr -> Parser (Formatted Attr)
+    go :: Attr -> Parser AnsiFormatted
     go attr = endOfInput *> pure mempty
           <|> formattedText attr
 
-    formattedText :: Attr -> Parser (Formatted Attr)
+    formattedText :: Attr -> Parser AnsiFormatted
     formattedText attr = do
         acs <- many attrChange
         let attr' = foldr ($) attr acs

--- a/src/Vgrep/Ansi/Parser.hs
+++ b/src/Vgrep/Ansi/Parser.hs
@@ -28,7 +28,7 @@ Cat 12 [Text 6 "Hello ",Format 5 (Attr {attrStyle = KeepCurrent, attrForeColor =
 
 More elaborate example with nested foreground and background colors:
 
->>> parseAnsi "\ESC[40mHello \ESC[31mWorld\ESC[39m!"
+>>> parseAnsi "\ESC[m\ESC[40mHello \ESC[31mWorld\ESC[39m!"
 Cat 12 [Format 6 (Attr {attrStyle = KeepCurrent, attrForeColor = KeepCurrent, attrBackColor = SetTo (ISOColor 0)}) (Text 6 "Hello "),Format 5 (Attr {attrStyle = KeepCurrent, attrForeColor = SetTo (ISOColor 1), attrBackColor = SetTo (ISOColor 0)}) (Text 5 "World"),Format 1 (Attr {attrStyle = KeepCurrent, attrForeColor = KeepCurrent, attrBackColor = SetTo (ISOColor 0)}) (Text 1 "!")]
 
 Some CSI sequences are ignored, since they are not supported by 'Vty':
@@ -65,7 +65,7 @@ ansiFormatted = go mempty
     formattedText :: Attr -> Parser AnsiFormatted
     formattedText attr = do
         acs <- many attrChange
-        let attr' = foldr ($) attr acs
+        let attr' = foldr ($) attr (reverse acs)
         t <- rawText
         rest <- go attr'
         pure (format attr' (bare t) <> rest)

--- a/src/Vgrep/Ansi/Parser.hs
+++ b/src/Vgrep/Ansi/Parser.hs
@@ -51,13 +51,13 @@ csi = csiEscape >> liftA2 Csi (decimal `sepBy` char ';') anyChar
 
 data Csi = Csi [Int] Char
 
-csiToAttrChange :: Csi -> (Attr -> Attr)
+csiToAttrChange :: Csi -> Attr -> Attr
 csiToAttrChange = \case
     Csi [] 'm' -> const mempty
     Csi is 'm' -> foldMap attrChangeFromCode is
     _otherwise -> id
 
-attrChangeFromCode :: Int -> (Attr -> Attr)
+attrChangeFromCode :: Int -> Attr -> Attr
 attrChangeFromCode = \case
     0  -> const mempty
     1  -> withStyle Vty.bold

--- a/src/Vgrep/Ansi/Parser.hs
+++ b/src/Vgrep/Ansi/Parser.hs
@@ -36,7 +36,7 @@ ansiFormatted = go mempty
     unformattedText attr = do
         t <- rawText
         rest <- go attr
-        pure (format attr (bare t) <> rest)
+        pure (bare t <> rest)
     rawText = takeTill (== '\ESC') <|> takeText
 
 

--- a/src/Vgrep/Ansi/Parser.hs
+++ b/src/Vgrep/Ansi/Parser.hs
@@ -30,13 +30,14 @@ ansiFormatted = go mempty
           <|> unformattedText attr
     formattedText attr = do
         ac <- attrChange
+        let attr' = ac attr
         t  <- rawText
-        rest <- go (ac attr)
-        pure (Leaf (ac attr) t <> rest)
+        rest <- go attr'
+        pure (Format attr' (Text t) <> rest)
     unformattedText attr = do
         t <- rawText
-        rest <- go (attr)
-        pure (Leaf attr t <> rest)
+        rest <- go attr
+        pure (Format attr (Text t) <> rest)
     rawText = takeTill (== '\ESC') <|> takeText
 
 

--- a/src/Vgrep/Ansi/Type.hs
+++ b/src/Vgrep/Ansi/Type.hs
@@ -1,7 +1,15 @@
-module Vgrep.Ansi.Type where
+module Vgrep.Ansi.Type
+  ( Formatted (..)
+  , empty
+  , bare
+  , format
+  , cat
+  , mapText
+  ) where
 
 
-import Data.Text (Text)
+import           Data.Text (Text)
+import qualified Data.Text as T
 
 
 data Formatted attr
@@ -33,6 +41,27 @@ instance (Eq attr, Monoid attr) => Monoid (Formatted attr) where
                                               Cat ts' -> Cat (ts' ++ ts)
                                               t'      -> Cat (t' : ts)
     formatted     `mappend` formatted'    = Cat [formatted, formatted']
+
+
+empty :: Formatted attr
+empty = Empty
+
+bare :: Text -> Formatted attr
+bare t
+    | T.null t  = empty
+    | otherwise = Text t
+
+format :: Monoid attr => attr -> Formatted attr -> Formatted attr
+format attr formatted
+    | Format attr' formatted' <- formatted
+                = format (attr `mappend` attr') formatted'
+    | otherwise = Format attr formatted
+
+cat :: (Eq attr, Monoid attr) => [Formatted attr] -> Formatted attr
+cat = \case
+    []  -> empty
+    [t] -> t
+    ts  -> mconcat ts
 
 
 mapText :: (Text -> Text) -> Formatted a -> Formatted a

--- a/src/Vgrep/Ansi/Type.hs
+++ b/src/Vgrep/Ansi/Type.hs
@@ -11,6 +11,7 @@ module Vgrep.Ansi.Type
   ) where
 
 import           Data.Foldable (foldl')
+import           Data.Monoid   ((<>))
 import           Data.Text     (Text)
 import qualified Data.Text     as T
 import           Prelude       hiding (length)
@@ -78,7 +79,7 @@ format :: (Eq attr, Monoid attr) => attr -> Formatted attr -> Formatted attr
 format attr formatted
     | attr == mempty = formatted
     | Format l attr' formatted' <- formatted
-                     = Format l (attr `mappend` attr') formatted'
+                     = Format l (attr <> attr') formatted'
     | otherwise      = format' attr formatted
 
 format' :: attr -> Formatted attr -> Formatted attr
@@ -112,9 +113,9 @@ fuse :: (Eq attr, Monoid attr) => Formatted attr -> Formatted attr -> Formatted 
 fuse left right = case (left, right) of
     (Empty,           formatted)    -> formatted
     (formatted,       Empty)        -> formatted
-    (Text l t,        Text l' t')   -> Text (l + l') (t `mappend` t')
+    (Text l t,        Text l' t')   -> Text (l + l') (t <> t')
     (Format l attr t, Format l' attr' t')
-        | attr' == attr             -> Format (l + l') attr (t `mappend` t')
+        | attr' == attr             -> Format (l + l') attr (t <> t')
 
     (Cat l ts,        Cat l' ts')   -> Cat (l + l') (ts ++ ts')
     (Cat l ts,        formatted)    -> Cat (l + length formatted) (ts ++ [formatted])

--- a/src/Vgrep/Ansi/Type.hs
+++ b/src/Vgrep/Ansi/Type.hs
@@ -41,11 +41,12 @@ bare t
     | T.null t  = empty
     | otherwise = Text (T.length t) t
 
-format :: Monoid attr => attr -> Formatted attr -> Formatted attr
+format :: (Eq attr, Monoid attr) => attr -> Formatted attr -> Formatted attr
 format attr formatted
+    | attr == mempty = formatted
     | Format l attr' formatted' <- formatted
-                = Format l (attr `mappend` attr') formatted'
-    | otherwise = format' attr formatted
+                     = Format l (attr `mappend` attr') formatted'
+    | otherwise      = format' attr formatted
 
 format' :: attr -> Formatted attr -> Formatted attr
 format' attr formatted = Format (length formatted) attr formatted

--- a/src/Vgrep/Ansi/Type.hs
+++ b/src/Vgrep/Ansi/Type.hs
@@ -1,9 +1,11 @@
 module Vgrep.Ansi.Type
   ( Formatted (..)
+  -- * Smart constructors
   , empty
   , bare
   , format
   , cat
+  -- * Modifying the underlying text
   , mapText
   , mapTextWithPos
   ) where
@@ -14,11 +16,21 @@ import qualified Data.Text     as T
 import           Prelude       hiding (length)
 
 
+-- | A representattion of formatted 'Text'. The attribute is usually a 'Monoid'
+-- so that different formattings can be combined by nesting them.
 data Formatted attr
     = Empty
+    -- ^ An empty block
+
     | Text !Int Text
+    -- ^ A bare (unformatted) text node
+
     | Format !Int attr (Formatted attr)
+    -- ^ Adds formatting to a block
+
     | Cat !Int [Formatted attr]
+    -- ^ Concatenates several blocks of formatted text
+
     deriving (Eq, Show)
 
 instance Functor Formatted where
@@ -33,14 +45,35 @@ instance (Eq attr, Monoid attr) => Monoid (Formatted attr) where
     mappend = fuse
 
 
+-- | Smart constructor for an empty 'Formatted' text.
 empty :: Formatted attr
 empty = Empty
 
+-- | Smart constructor for bare (unformatted) text.
+--
+-- >>> bare ""
+-- Empty
+--
+-- >>> bare "Text"
+-- Text 4 "Text"
+--
 bare :: Text -> Formatted attr
 bare t
     | T.null t  = empty
     | otherwise = Text (T.length t) t
 
+-- | Adds formatting to a 'Formatted' text. The 'Eq' and 'Monoid' instances for
+-- @attr@ are used to flatten redundant formattings.
+--
+-- >>> format (Just ()) (format Nothing (bare "Text"))
+-- Format 4 (Just ()) (Text 4 "Text")
+--
+-- >>> format (Just ()) (format (Just ()) (bare "Text"))
+-- Format 4 (Just ()) (Text 4 "Text")
+--
+-- >>> format Nothing (bare "Text")
+-- Text 4 "Text"
+--
 format :: (Eq attr, Monoid attr) => attr -> Formatted attr -> Formatted attr
 format attr formatted
     | attr == mempty = formatted
@@ -51,6 +84,8 @@ format attr formatted
 format' :: attr -> Formatted attr -> Formatted attr
 format' attr formatted = Format (length formatted) attr formatted
 
+-- | Concatenates pieces of 'Formatted' text. Redundant formattings and blocks
+-- of equal formatting are 'fuse'd together.
 cat :: (Eq attr, Monoid attr) => [Formatted attr] -> Formatted attr
 cat = \case
     []  -> empty
@@ -63,6 +98,16 @@ cat' = \case
     [t] -> t
     ts  -> Cat (sum (fmap length ts)) ts
 
+-- | Simplifies 'Formatted' text by leaving out redundant empty bits, joining
+-- pieces of text with the same formatting, and flattening redundant
+-- applications of the same style.
+--
+-- >>> empty `fuse` bare "Text"
+-- Text 4 "Text"
+--
+-- >>> format (Just ()) (bare "Left") `fuse` format (Just ()) (bare "Right")
+-- Format 9 (Just ()) (Text 9 "LeftRight")
+--
 fuse :: (Eq attr, Monoid attr) => Formatted attr -> Formatted attr -> Formatted attr
 fuse left right = case (left, right) of
     (Empty,           formatted)    -> formatted
@@ -87,6 +132,11 @@ length = \case
 
 
 
+-- | Apply a function to each piece of text in the 'Formatted' tree.
+--
+-- >>> mapText T.toUpper (Cat 11 [Text 6 "Hello ", Format 5 () (Text 5 "World")])
+-- Cat 11 [Text 6 "HELLO ",Format 5 () (Text 5 "WORLD")]
+--
 mapText :: (Text -> Text) -> Formatted a -> Formatted a
 mapText f = \case
     Empty           -> empty
@@ -94,6 +144,9 @@ mapText f = \case
     Format _ attr t -> format' attr (mapText f t)
     Cat _ ts        -> cat' (map (mapText f) ts)
 
+-- | Like 'mapText', but passes the position of the text chunk to the function
+-- as well. Can be used for formatting text position-dependently, e.g. for
+-- expanding tabs to spaces.
 mapTextWithPos :: (Int -> Text -> Text) -> Formatted a -> Formatted a
 mapTextWithPos f = go 0
   where

--- a/src/Vgrep/Ansi/Type.hs
+++ b/src/Vgrep/Ansi/Type.hs
@@ -1,4 +1,4 @@
-module Vgrep.Ansi.Types where
+module Vgrep.Ansi.Type where
 
 
 import Data.Text (Text)

--- a/src/Vgrep/Ansi/Type.hs
+++ b/src/Vgrep/Ansi/Type.hs
@@ -2,39 +2,42 @@ module Vgrep.Ansi.Type where
 
 
 import Data.Text (Text)
-import qualified Data.Text as T
 
 
-data Formatted attr = Node attr [Formatted attr] | Leaf attr Text
+data Formatted attr
+    = Empty
+    | Text Text
+    | Format attr (Formatted attr)
+    | Cat [Formatted attr]
     deriving (Eq, Show)
 
 instance Functor Formatted where
     fmap f = \case
-        Node attr ts -> Node (f attr) (map (fmap f) ts)
-        Leaf attr t  -> Leaf (f attr) t
+        Empty      -> Empty
+        Text t     -> Text t
+        Format a t -> Format (f a) (fmap f t)
+        Cat ts     -> Cat (map (fmap f) ts)
 
 instance (Eq attr, Monoid attr) => Monoid (Formatted attr) where
-    mempty = Leaf mempty T.empty
+    mempty = Empty
 
-    Node attr ts `mappend` Leaf attr' t
-        | T.null t           = Node attr  ts
-        | null ts            = Leaf attr' t
-        | attr  == mempty    = Node attr  (ts ++ [Leaf attr' t])
-        | attr  == attr'     = Node attr  (ts ++ [Leaf mempty t])
-    Leaf attr t  `mappend` Node attr' ts
-        | T.null t           = Node attr' ts
-        | null ts            = Leaf attr  t
-        | attr' == mempty    = Node attr' (Leaf attr t   : ts)
-        | attr' == attr      = Node attr' (Leaf mempty t : ts)
-    Leaf attr t  `mappend` Leaf attr' t'
-        | T.null t           = Leaf attr' t'
-        | T.null t'          = Leaf attr  t
-        | attr == attr'      = Leaf attr  (t `mappend` t')
-    Node attr ts `mappend` Node attr' ts'
-        | attr == attr'      = Node attr  (ts ++ ts')
-    l            `mappend` r = Node mempty [l, r]
+    Empty         `mappend` formatted     = formatted
+    formatted     `mappend` Empty         = formatted
+    Text t        `mappend` Text t'       = Text (t `mappend` t')
+    Format attr t `mappend` Format attr' t'
+        | attr' == attr                   = Format attr (t `mappend` t')
+
+    Cat ts        `mappend` Cat ts'       = Cat (ts ++ ts')
+    Cat ts        `mappend` formatted     = Cat (ts ++ [formatted])
+    formatted     `mappend` Cat (t:ts)    = case formatted `mappend` t of
+                                              Cat ts' -> Cat (ts' ++ ts)
+                                              t'      -> Cat (t' : ts)
+    formatted     `mappend` formatted'    = Cat [formatted, formatted']
+
 
 mapText :: (Text -> Text) -> Formatted a -> Formatted a
 mapText f = \case
-    Node attr ts -> Node attr (fmap (mapText f) ts)
-    Leaf attr t  -> Leaf attr (f t)
+    Empty         -> Empty
+    Text t        -> Text (f t)
+    Format attr t -> Format attr (mapText f t)
+    Cat ts        -> Cat (map (mapText f) ts)

--- a/src/Vgrep/Ansi/Type.hs
+++ b/src/Vgrep/Ansi/Type.hs
@@ -1,5 +1,6 @@
 module Vgrep.Ansi.Type
   ( Formatted (..)
+  , AnsiFormatted
   -- * Smart constructors
   , emptyFormatted
   , bare
@@ -14,6 +15,7 @@ import           Data.Foldable (foldl')
 import           Data.Monoid   ((<>))
 import           Data.Text     (Text)
 import qualified Data.Text     as T
+import           Graphics.Vty  (Attr)
 import           Prelude       hiding (length)
 
 
@@ -44,6 +46,10 @@ instance Functor Formatted where
 instance (Eq attr, Monoid attr) => Monoid (Formatted attr) where
     mempty = Empty
     mappend = fuse
+
+
+-- | Type alias for Text formatted with 'Attr' from "Graphics.Vty".
+type AnsiFormatted = Formatted Attr
 
 
 -- | Smart constructor for an empty 'Formatted' text.

--- a/src/Vgrep/Ansi/Type.hs
+++ b/src/Vgrep/Ansi/Type.hs
@@ -9,6 +9,8 @@ module Vgrep.Ansi.Type
   -- * Modifying the underlying text
   , mapText
   , mapTextWithPos
+  -- * Internal helpers
+  , fuse
   ) where
 
 import           Data.Foldable (foldl')

--- a/src/Vgrep/Ansi/Type.hs
+++ b/src/Vgrep/Ansi/Type.hs
@@ -5,6 +5,7 @@ module Vgrep.Ansi.Type
   , format
   , cat
   , mapText
+  , mapTextWithPos
   ) where
 
 import           Data.Foldable (foldl')
@@ -91,3 +92,18 @@ mapText f = \case
     Text _ t        -> bare (f t)
     Format _ attr t -> format' attr (mapText f t)
     Cat _ ts        -> cat' (map (mapText f) ts)
+
+mapTextWithPos :: (Int -> Text -> Text) -> Formatted a -> Formatted a
+mapTextWithPos f = go 0
+  where
+    go pos = \case
+        Empty           -> empty
+        Text _ t        -> bare (f pos t)
+        Format _ attr t -> format' attr (go pos t)
+        Cat _ ts        -> cat' (go2 pos ts)
+    go2 pos = \case
+        []     -> []
+        t : ts -> let t'  = go pos t
+                      l'  = length t'
+                      ts' = go2 (pos + l') ts
+                  in  t' : ts'

--- a/src/Vgrep/Ansi/Type.hs
+++ b/src/Vgrep/Ansi/Type.hs
@@ -1,7 +1,7 @@
 module Vgrep.Ansi.Type
   ( Formatted (..)
   -- * Smart constructors
-  , empty
+  , emptyFormatted
   , bare
   , format
   , cat
@@ -47,8 +47,8 @@ instance (Eq attr, Monoid attr) => Monoid (Formatted attr) where
 
 
 -- | Smart constructor for an empty 'Formatted' text.
-empty :: Formatted attr
-empty = Empty
+emptyFormatted :: Formatted attr
+emptyFormatted = Empty
 
 -- | Smart constructor for bare (unformatted) text.
 --
@@ -60,7 +60,7 @@ empty = Empty
 --
 bare :: Text -> Formatted attr
 bare t
-    | T.null t  = empty
+    | T.null t  = emptyFormatted
     | otherwise = Text (T.length t) t
 
 -- | Adds formatting to a 'Formatted' text. The 'Eq' and 'Monoid' instances for
@@ -89,13 +89,13 @@ format' attr formatted = Format (length formatted) attr formatted
 -- of equal formatting are 'fuse'd together.
 cat :: (Eq attr, Monoid attr) => [Formatted attr] -> Formatted attr
 cat = \case
-    []  -> empty
+    []  -> emptyFormatted
     [t] -> t
-    ts  -> foldl' fuse empty ts
+    ts  -> foldl' fuse emptyFormatted ts
 
 cat' :: [Formatted attr] -> Formatted attr
 cat' = \case
-    []  -> empty
+    []  -> emptyFormatted
     [t] -> t
     ts  -> Cat (sum (fmap length ts)) ts
 
@@ -103,7 +103,7 @@ cat' = \case
 -- pieces of text with the same formatting, and flattening redundant
 -- applications of the same style.
 --
--- >>> empty `fuse` bare "Text"
+-- >>> emptyFormatted `fuse` bare "Text"
 -- Text 4 "Text"
 --
 -- >>> format (Just ()) (bare "Left") `fuse` format (Just ()) (bare "Right")
@@ -140,7 +140,7 @@ length = \case
 --
 mapText :: (Text -> Text) -> Formatted a -> Formatted a
 mapText f = \case
-    Empty           -> empty
+    Empty           -> emptyFormatted
     Text _ t        -> bare (f t)
     Format _ attr t -> format' attr (mapText f t)
     Cat _ ts        -> cat' (map (mapText f) ts)
@@ -152,7 +152,7 @@ mapTextWithPos :: (Int -> Text -> Text) -> Formatted a -> Formatted a
 mapTextWithPos f = go 0
   where
     go pos = \case
-        Empty           -> empty
+        Empty           -> emptyFormatted
         Text _ t        -> bare (f pos t)
         Format _ attr t -> format' attr (go pos t)
         Cat _ ts        -> cat' (go2 pos ts)

--- a/src/Vgrep/Ansi/Types.hs
+++ b/src/Vgrep/Ansi/Types.hs
@@ -33,3 +33,8 @@ instance (Eq attr, Monoid attr) => Monoid (Formatted attr) where
     Node attr ts `mappend` Node attr' ts'
         | attr == attr'      = Node attr  (ts ++ ts')
     l            `mappend` r = Node mempty [l, r]
+
+mapText :: (Text -> Text) -> Formatted a -> Formatted a
+mapText f = \case
+    Node attr ts -> Node attr (fmap (mapText f) ts)
+    Leaf attr t  -> Leaf attr (f t)

--- a/src/Vgrep/Ansi/Types.hs
+++ b/src/Vgrep/Ansi/Types.hs
@@ -1,0 +1,35 @@
+module Vgrep.Ansi.Types where
+
+
+import Data.Text (Text)
+import qualified Data.Text as T
+
+
+data Formatted attr = Node attr [Formatted attr] | Leaf attr Text
+    deriving (Eq, Show)
+
+instance Functor Formatted where
+    fmap f = \case
+        Node attr ts -> Node (f attr) (map (fmap f) ts)
+        Leaf attr t  -> Leaf (f attr) t
+
+instance (Eq attr, Monoid attr) => Monoid (Formatted attr) where
+    mempty = Leaf mempty T.empty
+
+    Node attr ts `mappend` Leaf attr' t
+        | T.null t           = Node attr  ts
+        | null ts            = Leaf attr' t
+        | attr  == mempty    = Node attr  (ts ++ [Leaf attr' t])
+        | attr  == attr'     = Node attr  (ts ++ [Leaf mempty t])
+    Leaf attr t  `mappend` Node attr' ts
+        | T.null t           = Node attr' ts
+        | null ts            = Leaf attr  t
+        | attr' == mempty    = Node attr' (Leaf attr t   : ts)
+        | attr' == attr      = Node attr' (Leaf mempty t : ts)
+    Leaf attr t  `mappend` Leaf attr' t'
+        | T.null t           = Leaf attr' t'
+        | T.null t'          = Leaf attr  t
+        | attr == attr'      = Leaf attr  (t `mappend` t')
+    Node attr ts `mappend` Node attr' ts'
+        | attr == attr'      = Node attr  (ts ++ ts')
+    l            `mappend` r = Node mempty [l, r]

--- a/src/Vgrep/Ansi/Vty/Attributes.hs
+++ b/src/Vgrep/Ansi/Vty/Attributes.hs
@@ -1,0 +1,20 @@
+module Vgrep.Ansi.Vty.Attributes
+  ( Attr ()
+  , combineStyles
+  ) where
+
+import Data.Bits               ((.|.))
+import Data.Monoid             ((<>))
+import Graphics.Vty.Attributes (Attr (..), MaybeDefault (..))
+
+-- | Combines two 'Attr's. This differs from 'mappend' from the 'Monoid'
+-- instance of 'Attr' in that 'Vty.Style's are combined rather than
+-- overwritten.
+combineStyles :: Attr -> Attr -> Attr
+combineStyles l r = Attr
+    { attrStyle = case (attrStyle l, attrStyle r) of
+        (SetTo l', SetTo r') -> SetTo (l' .|. r')
+        (l', r')             -> l' <> r'
+    , attrForeColor = attrForeColor l <> attrForeColor r
+    , attrBackColor = attrBackColor l <> attrBackColor r
+    }

--- a/src/Vgrep/Parser.hs
+++ b/src/Vgrep/Parser.hs
@@ -13,6 +13,8 @@ import Data.Maybe
 import Data.Text            hiding (takeWhile)
 import Prelude              hiding (takeWhile)
 
+import Vgrep.Ansi        (stripAnsi)
+import Vgrep.Ansi.Parser (attrChange, parseAnsi)
 import Vgrep.Results
 
 
@@ -47,11 +49,11 @@ parseLine line = case parseOnly lineParser line of
 lineParser :: Parser FileLineReference
 lineParser = do
     file       <- takeWhile (/= ':') <* char ':'
-    lineNumber <- optional (decimal <* char ':')
+    lineNumber <- optional (skipMany attrChange *> decimal <* skipMany attrChange <* char ':')
     result     <- takeText
     pure FileLineReference
         { getFile = File
-            { getFileName = file }
+            { getFileName = stripAnsi (parseAnsi file) }
         , getLineReference = LineReference
             { getLineNumber = lineNumber
-            , getLineText   = result } }
+            , getLineText   = parseAnsi result } }

--- a/src/Vgrep/Parser.hs
+++ b/src/Vgrep/Parser.hs
@@ -30,17 +30,23 @@ parseGrepOutput = catMaybes . fmap parseLine
 -- separated by colons:
 --
 -- >>> parseLine "path/to/file:123:foobar"
--- Just (FileLineReference {getFile = File {getFileName = "path/to/file"}, getLineReference = LineReference {getLineNumber = Just 123, getLineText = "foobar"}})
+-- Just (FileLineReference {_file = File {_fileName = "path/to/file"}, _lineReference = LineReference {_lineNumber = Just 123, _lineText = Text 6 "foobar"}})
 --
 -- Omitting the line number still produces valid output:
 --
 -- >>> parseLine "path/to/file:foobar"
--- Just (FileLineReference {getFile = File {getFileName = "path/to/file"}, getLineReference = LineReference {getLineNumber = Nothing, getLineText = "foobar"}})
+-- Just (FileLineReference {_file = File {_fileName = "path/to/file"}, _lineReference = LineReference {_lineNumber = Nothing, _lineText = Text 6 "foobar"}})
 --
 -- However, an file name must be present:
 --
 -- >>> parseLine "foobar"
 -- Nothing
+--
+-- ANSI escape codes in the line text are parsed correctly:
+--
+-- >>> parseLine "path/to/file:foo\ESC[31mbar\ESC[mbaz"
+-- Just (FileLineReference {_file = File {_fileName = "path/to/file"}, _lineReference = LineReference {_lineNumber = Nothing, _lineText = Cat 9 [Text 3 "foo",Format 3 (Attr {attrStyle = KeepCurrent, attrForeColor = SetTo (ISOColor 1), attrBackColor = KeepCurrent}) (Text 3 "bar"),Text 3 "baz"]}})
+--
 parseLine :: Text -> Maybe FileLineReference
 parseLine line = case parseOnly lineParser line of
     Left  _      -> Nothing

--- a/src/Vgrep/Parser.hs
+++ b/src/Vgrep/Parser.hs
@@ -15,7 +15,7 @@ import Prelude              hiding (takeWhile)
 
 import Vgrep.Ansi        (stripAnsi)
 import Vgrep.Ansi.Parser (attrChange, parseAnsi)
-import Vgrep.Results
+import Vgrep.Results     (File (..), FileLineReference (..), LineReference (..))
 
 
 -- | Parses lines of 'Text', skipping lines that are not valid @grep@
@@ -52,8 +52,8 @@ lineParser = do
     lineNumber <- optional (skipMany attrChange *> decimal <* skipMany attrChange <* char ':')
     result     <- takeText
     pure FileLineReference
-        { getFile = File
-            { getFileName = stripAnsi (parseAnsi file) }
-        , getLineReference = LineReference
-            { getLineNumber = lineNumber
-            , getLineText   = parseAnsi result } }
+        { _file = File
+            { _fileName = stripAnsi (parseAnsi file) }
+        , _lineReference = LineReference
+            { _lineNumber = lineNumber
+            , _lineText   = parseAnsi result } }

--- a/src/Vgrep/Results.hs
+++ b/src/Vgrep/Results.hs
@@ -12,10 +12,10 @@ module Vgrep.Results
     , lineReference
     ) where
 
-import Data.Text (Text)
 import Control.Lens.TH
+import Data.Text       (Text)
 
-import Vgrep.Ansi (Formatted, Attr)
+import Vgrep.Ansi (Attr (), Formatted ())
 
 
 newtype File = File

--- a/src/Vgrep/Results.hs
+++ b/src/Vgrep/Results.hs
@@ -15,7 +15,7 @@ module Vgrep.Results
 import Control.Lens.TH
 import Data.Text       (Text)
 
-import Vgrep.Ansi (Attr (), Formatted ())
+import Vgrep.Ansi (AnsiFormatted)
 
 
 newtype File = File
@@ -26,7 +26,7 @@ makeLenses ''File
 
 data LineReference = LineReference
     { _lineNumber :: Maybe Int
-    , _lineText   :: Formatted Attr
+    , _lineText   :: AnsiFormatted
     } deriving (Eq, Show)
 
 makeLenses ''LineReference

--- a/src/Vgrep/Results.hs
+++ b/src/Vgrep/Results.hs
@@ -6,6 +6,8 @@ module Vgrep.Results
 
 import Data.Text (Text)
 
+import Vgrep.Ansi (Formatted, Attr)
+
 
 newtype File = File
     { getFileName :: Text
@@ -13,7 +15,7 @@ newtype File = File
 
 data LineReference = LineReference
     { getLineNumber :: Maybe Int
-    , getLineText   :: Text
+    , getLineText   :: Formatted Attr
     } deriving (Eq, Show)
 
 data FileLineReference = FileLineReference

--- a/src/Vgrep/Results.hs
+++ b/src/Vgrep/Results.hs
@@ -1,24 +1,39 @@
+{-# LANGUAGE TemplateHaskell #-}
 module Vgrep.Results
     ( File (..)
+    , fileName
+
     , LineReference (..)
+    , lineNumber
+    , lineText
+
     , FileLineReference (..)
+    , file
+    , lineReference
     ) where
 
 import Data.Text (Text)
+import Control.Lens.TH
 
 import Vgrep.Ansi (Formatted, Attr)
 
 
 newtype File = File
-    { getFileName :: Text
+    { _fileName :: Text
     } deriving (Eq, Show)
+
+makeLenses ''File
 
 data LineReference = LineReference
-    { getLineNumber :: Maybe Int
-    , getLineText   :: Formatted Attr
+    { _lineNumber :: Maybe Int
+    , _lineText   :: Formatted Attr
     } deriving (Eq, Show)
 
+makeLenses ''LineReference
+
 data FileLineReference = FileLineReference
-    { getFile          :: File
-    , getLineReference :: LineReference
+    { _file          :: File
+    , _lineReference :: LineReference
     } deriving (Eq, Show)
+
+makeLenses ''FileLineReference

--- a/src/Vgrep/System/Grep.hs
+++ b/src/Vgrep/System/Grep.hs
@@ -50,7 +50,7 @@ grep input = do
 
 grepPipe :: [String] -> Producer Text IO () -> Producer Text IO ()
 grepPipe args input = do
-    (hIn, hOut) <- createGrepProcess (lineBuffered : args)
+    (hIn, hOut) <- createGrepProcess (lineBuffered : colorized : args)
     _threadId <- liftIO . forkIO . runEffect $ input >-> textToHandle hIn
     streamResultsFrom hOut
 
@@ -66,6 +66,7 @@ recursiveGrep = do
                  : withLineNumber
                  : skipBinaryFiles
                  : lineBuffered
+                 : colorized
                  : args
     (_hIn, hOut) <- createGrepProcess grepArgs
     streamResultsFrom hOut
@@ -75,12 +76,13 @@ grepVersion = do
     (_, hOut) <- createGrepProcess [version]
     streamResultsFrom hOut
 
-recursive, withFileName, withLineNumber, skipBinaryFiles, lineBuffered, version :: String
+recursive, withFileName, withLineNumber, skipBinaryFiles, lineBuffered, colorized, version :: String
 recursive       = "-r"
 withFileName    = "-H"
 withLineNumber  = "-n"
 skipBinaryFiles = "-I"
 lineBuffered    = "--line-buffered"
+colorized       = "--color=always"
 version         = "--version"
 
 

--- a/src/Vgrep/Text.hs
+++ b/src/Vgrep/Text.hs
@@ -25,26 +25,26 @@ expandForDisplay
     => f Text -> m (f Text)
 expandForDisplay inputLines = do
     tabWidth <- view (config . tabstop)
-    pure (fmap (expandText tabWidth) inputLines)
+    pure (fmap (expandText tabWidth 0) inputLines)
 
 -- | Expand a single line
 expandLineForDisplay :: MonadReader Environment m => Text -> m Text
 expandLineForDisplay inputLine = do
     tabWidth <- view (config . tabstop)
-    pure (expandText tabWidth inputLine)
+    pure (expandText tabWidth 0 inputLine)
 
 -- | Expand an ANSI formatted line
 expandFormattedLine :: MonadReader Environment m => Formatted a -> m (Formatted a)
 expandFormattedLine inputLine = do
     tabWidth <- view (config . tabstop)
-    pure (mapText (expandText tabWidth) inputLine) -- FIXME tabs!
+    pure (mapTextWithPos (expandText tabWidth) inputLine)
 
-expandText :: Int -> Text -> Text
-expandText tabWidth =
-    T.pack . expandSpecialChars . expandTabs tabWidth . T.unpack
+expandText :: Int -> Int -> Text -> Text
+expandText tabWidth pos =
+    T.pack . expandSpecialChars . expandTabs tabWidth pos . T.unpack
 
-expandTabs :: Int -> String -> String
-expandTabs tabWidth = go 0
+expandTabs :: Int -> Int -> String -> String
+expandTabs tabWidth = go
   where go pos (c:cs)
             | c == '\t' = let shift = tabWidth - (pos `mod` tabWidth)
                           in  replicate shift ' ' ++ go (pos + shift) cs

--- a/src/Vgrep/Text.hs
+++ b/src/Vgrep/Text.hs
@@ -2,8 +2,8 @@
 module Vgrep.Text (
     -- * Utilities for rendering 'Text'
     -- | Tabs and other characters below ASCII 32 cause problems in
-    -- "Graphics.Vty", so we expand them to readable characters, e.g. @\\r@
-    -- to @^13@. Tabs are expanded toh the configured 'tabWidth'.
+    -- "Graphics.Vty", so we expand them to readable characters, e.g. @\\r@ to
+    -- @^13@. Tabs are expanded to the configured 'Vgrep.Environment._tabstop'.
       expandForDisplay
     , expandLineForDisplay
     , expandFormattedLine

--- a/src/Vgrep/Text.hs
+++ b/src/Vgrep/Text.hs
@@ -45,6 +45,7 @@ expandTabs tabWidth = go 0
 
 expandSpecialChars :: String -> String
 expandSpecialChars = \case
-    c:cs | ord c < 32 -> ['^', chr (ord c + 64)] ++ expandSpecialChars cs
-         | otherwise  -> c : expandSpecialChars cs
-    []                -> []
+    cs@('\ESC':'[':_)  -> cs -- Keep escape sequences, to be parsed by ANSI parser
+    c:cs | ord c < 32  -> ['^', chr (ord c + 64)] ++ expandSpecialChars cs
+         | otherwise   -> c : expandSpecialChars cs
+    []                 -> []

--- a/src/Vgrep/Widget/Pager.hs
+++ b/src/Vgrep/Widget/Pager.hs
@@ -90,7 +90,7 @@ pagerKeyBindings = dispatchMap $ fromList
 replaceBufferContents
     :: Monad m
     => Seq Text -- ^ Lines of text to display in the pager (starting with line 1)
-    -> Map.IntMap (Formatted Attr) -- ^ Line numbers and formatted text for highlighted lines
+    -> Map.IntMap AnsiFormatted -- ^ Line numbers and formatted text for highlighted lines
     -> VgrepT Pager m ()
 replaceBufferContents newContent newHighlightedLines = put initPager
     { _visible     = newContent

--- a/src/Vgrep/Widget/Pager.hs
+++ b/src/Vgrep/Widget/Pager.hs
@@ -163,7 +163,7 @@ renderPager = do
 
     let renderLineNumber attr = padWithSpace attr . string attr . show
         renderLineText   attr = padWithSpace attr . cropScroll attr . text' attr
-        renderFormatted  attr = padWithSpace attr . cropScroll attr . renderAnsi . format attr
+        renderFormatted  attr = padWithSpace attr . cropScroll attr . renderAnsi attr
         padWithSpace attr txt = let space = string attr " "
                                 in  space <|> txt <|> space
         cropScroll attr = translateX (-startColumn)

--- a/src/Vgrep/Widget/Pager/Internal.hs
+++ b/src/Vgrep/Widget/Pager/Internal.hs
@@ -26,7 +26,7 @@ data Pager = Pager
     { _column      :: Int
     -- ^ The current column offset for horizontal scrolling
 
-    , _highlighted :: IntMap (Formatted Attr)
+    , _highlighted :: IntMap AnsiFormatted
     -- ^ Set of line numbers that are highlighted (i.e. they contain matches)
 
     , _above       :: Seq Text

--- a/src/Vgrep/Widget/Pager/Internal.hs
+++ b/src/Vgrep/Widget/Pager/Internal.hs
@@ -13,9 +13,11 @@ module Vgrep.Widget.Pager.Internal (
     ) where
 
 import Control.Lens.Compat
+import Data.IntMap.Strict  (IntMap)
 import Data.Sequence       (Seq)
-import Data.Set            (Set)
 import Data.Text           (Text)
+
+import Vgrep.Ansi
 
 
 -- | Keeps track of the lines of text to display, the current scroll
@@ -24,7 +26,7 @@ data Pager = Pager
     { _column      :: Int
     -- ^ The current column offset for horizontal scrolling
 
-    , _highlighted :: Set Int
+    , _highlighted :: IntMap (Formatted Attr)
     -- ^ Set of line numbers that are highlighted (i.e. they contain matches)
 
     , _above       :: Seq Text

--- a/src/Vgrep/Widget/Results.hs
+++ b/src/Vgrep/Widget/Results.hs
@@ -39,6 +39,7 @@ import           Graphics.Vty.Input
 import           Graphics.Vty.Prelude
 import           Prelude
 
+import Vgrep.Ansi
 import Vgrep.Environment
 import Vgrep.Event
 import Vgrep.Results
@@ -187,10 +188,11 @@ renderLine width lineNumberWidth displayLine = do
                           . justifyRight lineNumberWidth
                           . maybe "" (T.pack . show)
 
-    renderLineText :: Attr -> Text -> Image
-    renderLineText attr = text' attr
-                        . padWithSpace (width - lineNumberWidth)
-
+    renderLineText :: Attr -> Formatted Attr -> Image
+    renderLineText attr txt = cropRight (width - lineNumberWidth) . renderAnsi . Node attr $
+        [ Leaf mempty " "
+        , txt
+        , Leaf mempty (T.replicate width " ") ]
 
 resizeToWindow :: Monad m => VgrepT Results m Redraw
 resizeToWindow = do

--- a/src/Vgrep/Widget/Results.hs
+++ b/src/Vgrep/Widget/Results.hs
@@ -151,7 +151,7 @@ renderResultList = do
   where lineNumberWidth
             = foldl' max 0
             . map (twoExtraSpaces . length . show)
-            . mapMaybe lineNumber
+            . mapMaybe displayLineNumber
         twoExtraSpaces = (+ 2)
 
 renderLine
@@ -166,8 +166,8 @@ renderLine width lineNumberWidth displayLine = do
     resultLineStyle <- view (config . colors . normal)
     selectedStyle   <- view (config . colors . selected)
     pure $ case displayLine of
-        FileHeader (File file)
-            -> renderFileHeader fileHeaderStyle file
+        FileHeader (File f)
+            -> renderFileHeader fileHeaderStyle f
         Line         (LineReference n t)
             -> horizCat [ renderLineNumber lineNumberStyle n
                         , renderLineText   resultLineStyle t ]

--- a/src/Vgrep/Widget/Results.hs
+++ b/src/Vgrep/Widget/Results.hs
@@ -189,7 +189,7 @@ renderLine width lineNumberWidth displayLine = do
                           . maybe "" (T.pack . show)
 
     renderLineText :: Attr -> Formatted Attr -> Image
-    renderLineText attr txt = cropRight (width - lineNumberWidth) . renderAnsi . format attr $
+    renderLineText attr txt = cropRight (width - lineNumberWidth) . renderAnsi attr $
         cat [ bare " " , txt , bare (T.replicate width " ") ]
 
 resizeToWindow :: Monad m => VgrepT Results m Redraw

--- a/src/Vgrep/Widget/Results.hs
+++ b/src/Vgrep/Widget/Results.hs
@@ -168,7 +168,7 @@ renderLine width lineNumberWidth displayLine = do
     pure $ case displayLine of
         FileHeader (File f)
             -> renderFileHeader fileHeaderStyle f
-        Line         (LineReference n t)
+        Line (LineReference n t)
             -> horizCat [ renderLineNumber lineNumberStyle n
                         , renderLineText   resultLineStyle t ]
         SelectedLine (LineReference n t)

--- a/src/Vgrep/Widget/Results.hs
+++ b/src/Vgrep/Widget/Results.hs
@@ -190,8 +190,11 @@ renderLine width lineNumberWidth displayLine = do
                           . maybe "" (T.pack . show)
 
     renderLineText :: Attr -> AnsiFormatted -> Image
-    renderLineText attr txt = cropRight (width - lineNumberWidth) . renderAnsi attr $
-        cat [ bare " " , txt , bare (T.replicate width " ") ]
+    renderLineText attr txt
+        = renderAnsi attr
+        . takeFormatted (width - lineNumberWidth)
+        . padFormatted  (width - lineNumberWidth) ' '
+        $ cat [ bare " ", txt, bare (T.replicate width " ") ]
 
 resizeToWindow :: Monad m => VgrepT Results m Redraw
 resizeToWindow = do

--- a/src/Vgrep/Widget/Results.hs
+++ b/src/Vgrep/Widget/Results.hs
@@ -20,7 +20,7 @@ module Vgrep.Widget.Results (
     -- ** Lenses
     , currentFileName
     , currentLineNumber
-    , currentFileResultLineNumbers
+    , currentFileResults
 
     -- * Re-exports
     , module Vgrep.Results

--- a/src/Vgrep/Widget/Results.hs
+++ b/src/Vgrep/Widget/Results.hs
@@ -189,10 +189,10 @@ renderLine width lineNumberWidth displayLine = do
                           . maybe "" (T.pack . show)
 
     renderLineText :: Attr -> Formatted Attr -> Image
-    renderLineText attr txt = cropRight (width - lineNumberWidth) . renderAnsi . Node attr $
-        [ Leaf mempty " "
-        , txt
-        , Leaf mempty (T.replicate width " ") ]
+    renderLineText attr txt = cropRight (width - lineNumberWidth) . renderAnsi . Format attr $
+        Cat [ Text " "
+            , txt
+            , Text (T.replicate width " ") ]
 
 resizeToWindow :: Monad m => VgrepT Results m Redraw
 resizeToWindow = do

--- a/src/Vgrep/Widget/Results.hs
+++ b/src/Vgrep/Widget/Results.hs
@@ -152,7 +152,8 @@ renderResultList = do
             = foldl' max 0
             . map (twoExtraSpaces . length . show)
             . mapMaybe displayLineNumber
-        twoExtraSpaces = (+ 2)
+        twoExtraSpaces = (+ 2) -- because line numbers are padded,
+                               -- see `justifyRight` below
 
 renderLine
     :: Monad m

--- a/src/Vgrep/Widget/Results.hs
+++ b/src/Vgrep/Widget/Results.hs
@@ -188,7 +188,7 @@ renderLine width lineNumberWidth displayLine = do
                           . justifyRight lineNumberWidth
                           . maybe "" (T.pack . show)
 
-    renderLineText :: Attr -> Formatted Attr -> Image
+    renderLineText :: Attr -> AnsiFormatted -> Image
     renderLineText attr txt = cropRight (width - lineNumberWidth) . renderAnsi attr $
         cat [ bare " " , txt , bare (T.replicate width " ") ]
 

--- a/src/Vgrep/Widget/Results.hs
+++ b/src/Vgrep/Widget/Results.hs
@@ -189,10 +189,8 @@ renderLine width lineNumberWidth displayLine = do
                           . maybe "" (T.pack . show)
 
     renderLineText :: Attr -> Formatted Attr -> Image
-    renderLineText attr txt = cropRight (width - lineNumberWidth) . renderAnsi . Format attr $
-        Cat [ Text " "
-            , txt
-            , Text (T.replicate width " ") ]
+    renderLineText attr txt = cropRight (width - lineNumberWidth) . renderAnsi . format attr $
+        cat [ bare " " , txt , bare (T.replicate width " ") ]
 
 resizeToWindow :: Monad m => VgrepT Results m Redraw
 resizeToWindow = do

--- a/src/Vgrep/Widget/Results/Internal.hs
+++ b/src/Vgrep/Widget/Results/Internal.hs
@@ -45,7 +45,7 @@ import qualified Data.Sequence       as S
 import           Data.Text           (Text)
 import           Prelude             hiding (reverse)
 
-import Vgrep.Ansi    (Attr (), Formatted ())
+import Vgrep.Ansi    (AnsiFormatted)
 import Vgrep.Results
 
 
@@ -213,7 +213,7 @@ current = \case
 
 -- | The line numbers with matches in the file of the currentliy selected
 -- item
-currentFileResults :: Getter Results (IntMap (Formatted Attr))
+currentFileResults :: Getter Results (IntMap AnsiFormatted)
 currentFileResults =
     to (Map.fromList . lineReferencesInCurrentFile)
   where

--- a/test/Test/Vgrep/Widget/Pager.hs
+++ b/test/Test/Vgrep/Widget/Pager.hs
@@ -62,7 +62,7 @@ test = runTestCases "Pager widget"
         , testData = arbitrary
         , testCase = do
             newContent <- pick (fmap (S.fromList . map T.pack) arbitrary)
-            run (replaceBufferContents newContent [])
+            run (replaceBufferContents newContent mempty)
             pure newContent
         , assertion = \expectedContent -> do
             actualContent <- use visible

--- a/test/Vgrep/Widget/Results/Testable.hs
+++ b/test/Vgrep/Widget/Results/Testable.hs
@@ -12,7 +12,12 @@ import           Data.Text       (Text)
 import qualified Data.Text       as Text
 import           Test.QuickCheck
 
-import Vgrep.Widget.Results
+import Vgrep.Ansi
+import Vgrep.Widget.Results          hiding
+    ( fileName
+    , lineNumber
+    , lineReference
+    )
 import Vgrep.Widget.Results.Internal
 
 instance Arbitrary Results where
@@ -42,12 +47,15 @@ arbitraryGrepResults :: Gen [FileLineReference]
 arbitraryGrepResults = fmap concat . infiniteListOf $ do
     fileName <- arbitraryText
     lineReferences <- do
-        matches <- listOf arbitraryText
+        matches <- listOf arbitraryFormattedText
         lineNumbers <- maybeLineNumbers (length matches)
         pure (zipWith LineReference lineNumbers matches)
     pure [ FileLineReference (File fileName) lineReference
              | lineReference <- lineReferences ]
 
+
+arbitraryFormattedText :: Gen (Formatted attr)
+arbitraryFormattedText = fmap bare arbitraryText
 
 arbitraryText :: Gen Text
 arbitraryText = fmap Text.pack arbitrary

--- a/vgrep.cabal
+++ b/vgrep.cabal
@@ -40,7 +40,7 @@ library
                      , Pipes.Concurrent.PQueue
                      , Vgrep.Ansi
                      , Vgrep.Ansi.Parser
-                     , Vgrep.Ansi.Types
+                     , Vgrep.Ansi.Type
                      , Vgrep.App
                      , Vgrep.Environment
                      , Vgrep.Environment.Config

--- a/vgrep.cabal
+++ b/vgrep.cabal
@@ -41,6 +41,7 @@ library
                      , Vgrep.Ansi
                      , Vgrep.Ansi.Parser
                      , Vgrep.Ansi.Type
+                     , Vgrep.Ansi.Vty.Attributes
                      , Vgrep.App
                      , Vgrep.Environment
                      , Vgrep.Environment.Config

--- a/vgrep.cabal
+++ b/vgrep.cabal
@@ -38,6 +38,9 @@ library
                      , Control.Lens.Compat
                      , Control.Monad.State.Extended
                      , Pipes.Concurrent.PQueue
+                     , Vgrep.Ansi
+                     , Vgrep.Ansi.Parser
+                     , Vgrep.Ansi.Types
                      , Vgrep.App
                      , Vgrep.Environment
                      , Vgrep.Environment.Config


### PR DESCRIPTION
Parse ANSI escape codes in the grep output and format the output text accordingly (results list and pager).

`--color=always` now switched on by default for `grep` invocation.