### PR TITLE
Travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@
 sudo: false
 
 # Choose a lightweight base image; we provide our own build tools.
-language: c
+language: generic
 
 # GHC depends on GMP. You can add other dependencies here as well.
 addons:
@@ -15,13 +15,16 @@ addons:
 
 # The different configurations we want to test. You could also do things like
 # change flags or use --stack-yaml to point to a different file.
-env:
-    - ARGS=""
-    # - ARGS="--resolver lts-3"
-    # - ARGS="--resolver lts-4"
-    # - ARGS="--resolver lts-5"
-    # - ARGS="--resolver lts"
-    # - ARGS="--resolver nightly"
+matrix:
+    fast_finish: true
+    include:
+        - env: ARGS=""
+        - env: ARGS="--resolver lts-5"
+        - env: ARGS="--resolver lts-6"
+        - env: ARGS="--resolver lts-7"
+        - env: ARGS="--resolver lts"
+    allow_failures:
+        - env: ARGS="--resolver nightly"
 
 before_install:
     # Download and unpack the stack executable
@@ -29,8 +32,8 @@ before_install:
     - export PATH=$HOME/.local/bin:$PATH
     - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
 
-    - stack --no-terminal setup
-    - stack --no-terminal install hlint hscolour
+    - stack $ARGS --no-terminal setup
+    - stack $ARGS --no-terminal install hlint hscolour
 
 script:
     - stack $ARGS --no-terminal build --pedantic

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -4,7 +4,7 @@
 module Main (main) where
 
 import           Control.Concurrent.Async
-import           Control.Lens
+import           Control.Lens.Compat
 import           Control.Monad.Reader
 import           Data.Maybe
 import           Data.Monoid

--- a/src/Control/Lens/Compat.hs
+++ b/src/Control/Lens/Compat.hs
@@ -1,14 +1,3 @@
--- | In lens-4.14, the constraint @'Functor' f@ is missing from the definition
--- of 'to'. When compiling with GHC 8.0, this leads to warnings for definitions
--- like
---
--- @
--- foo :: Getter Bar Foo
--- foo = to fooFromBar
--- @
---
--- because of the redundant @'Functor' f@ constraint. This module exports an
--- alternative definition with the added @'Functor' f@ Constraint.
 module Control.Lens.Compat
   ( to
   , module Control.Lens
@@ -19,12 +8,22 @@ import qualified Control.Lens as Lens
 
 
 -- | Build an (index-preserving) 'Getter' from an arbitrary Haskell function.
+-- See "Control.Lens".'Lens.to' for details.
 --
--- Identical to "Control.Lens".'Lens.to' except for the additional constraint
+-- In <https://hackage.haskell.org/package/lens-4.14 lens-4.14>, the constraint
+-- @'Functor' f@ is missing from the definition of 'Lens.to'. When compiling
+-- with GHC 8.0, this leads to warnings for definitions like
+--
+-- @
+-- foo :: Getter Bar Foo
+-- foo = to fooFromBar
+-- @
+--
+-- because of the redundant @'Functor' f@ constraint. This definition is
+-- identical to "Control.Lens".'Lens.to' except for the additional constraint
 -- @'Functor' f@.
 to :: (Profunctor p, Functor f, Contravariant f) => (s -> a) -> Optic' p f s a
-to k = fakeFunctorConstraintToDisableGhc8WarningWithLens4_14 . Lens.to k
+to k = getter
   where
-    fakeFunctorConstraintToDisableGhc8WarningWithLens4_14 getter =
-        let _ = rmap (fmap undefined) getter
-        in  getter
+    getter = Lens.to k
+    _fakeFunctorConstraint = rmap (fmap undefined) . getter

--- a/src/Control/Lens/Compat.hs
+++ b/src/Control/Lens/Compat.hs
@@ -1,0 +1,30 @@
+-- | In lens-4.14, the constraint @'Functor' f@ is missing from the definition
+-- of 'to'. When compiling with GHC 8.0, this leads to warnings for definitions
+-- like
+--
+-- @
+-- foo :: Getter Bar Foo
+-- foo = to fooFromBar
+-- @
+--
+-- because of the redundant @'Functor' f@ constraint. This module exports an
+-- alternative definition with the added @'Functor' f@ Constraint.
+module Control.Lens.Compat
+  ( to
+  , module Control.Lens
+  ) where
+
+import           Control.Lens hiding (to)
+import qualified Control.Lens as Lens
+
+
+-- | Build an (index-preserving) 'Getter' from an arbitrary Haskell function.
+--
+-- Identical to "Control.Lens".'Lens.to' except for the additional constraint
+-- @'Functor' f@.
+to :: (Profunctor p, Functor f, Contravariant f) => (s -> a) -> Optic' p f s a
+to k = fakeFunctorConstraintToDisableGhc8WarningWithLens4_14 . Lens.to k
+  where
+    fakeFunctorConstraintToDisableGhc8WarningWithLens4_14 getter =
+        let _ = rmap (fmap undefined) getter
+        in  getter

--- a/src/Vgrep/Environment.hs
+++ b/src/Vgrep/Environment.hs
@@ -11,7 +11,7 @@ module Vgrep.Environment
     , module Graphics.Vty.Prelude
     ) where
 
-import Control.Lens
+import Control.Lens.Compat
 import Graphics.Vty.Prelude
 
 import Vgrep.Environment.Config

--- a/src/Vgrep/Environment/Config.hs
+++ b/src/Vgrep/Environment/Config.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 module Vgrep.Environment.Config where
 
-import Control.Lens
+import Control.Lens.Compat
 import Control.Monad.IO.Class
 import Data.Maybe
 import Data.Monoid

--- a/src/Vgrep/Environment/Config/Sources/File.hs
+++ b/src/Vgrep/Environment/Config/Sources/File.hs
@@ -21,6 +21,9 @@ import           System.IO
 
 import Vgrep.Environment.Config.Monoid
 
+-- $setup
+-- >>> import Data.List (isInfixOf)
+
 
 {- |
 Reads the configuration from a JSON or YAML file. The file should be
@@ -212,8 +215,9 @@ Right [Black,Red,BrightBlack]
 
 Fails with error message if the 'Color' cannot be parsed:
 
->>> decodeEither "foo" :: Either String Color
-Left "Unknown Color: foo"
+>>> let Left err = decodeEither "foo" :: Either String Color
+>>> "Unknown Color: foo" `isInfixOf` err
+True
 -}
 data Color
     = Black
@@ -287,8 +291,9 @@ Right [Standout,Underline,Bold]
 
 Fails with error message if the 'Style' cannot be parsed:
 
->>> decodeEither "foo" :: Either String Style
-Left "Unknown Style: foo"
+>>> let Left err = decodeEither "foo" :: Either String Style
+>>> "Unknown Style: foo" `isInfixOf` err
+True
 -}
 data Style
     = Standout

--- a/src/Vgrep/Text.hs
+++ b/src/Vgrep/Text.hs
@@ -8,7 +8,7 @@ module Vgrep.Text (
     , expandLineForDisplay
     ) where
 
-import           Control.Lens
+import           Control.Lens.Compat
 import           Control.Monad.Reader.Class
 import           Data.Char
 import           Data.Text                  (Text)

--- a/src/Vgrep/Widget/HorizontalSplit.hs
+++ b/src/Vgrep/Widget/HorizontalSplit.hs
@@ -22,9 +22,9 @@ module Vgrep.Widget.HorizontalSplit (
     , rightWidgetFocused
     ) where
 
-import Control.Lens
+import Control.Lens.Compat
 import Data.Monoid
-import Graphics.Vty.Image hiding (resize)
+import Graphics.Vty.Image  hiding (resize)
 import Graphics.Vty.Input
 
 import Vgrep.Environment

--- a/src/Vgrep/Widget/HorizontalSplit/Internal.hs
+++ b/src/Vgrep/Widget/HorizontalSplit/Internal.hs
@@ -19,8 +19,8 @@ module Vgrep.Widget.HorizontalSplit.Internal (
     , (%)
     ) where
 
-import Control.Lens
-import Data.Ratio   ((%))
+import Control.Lens.Compat
+import Data.Ratio          ((%))
 
 
 -- $setup

--- a/src/Vgrep/Widget/Pager.hs
+++ b/src/Vgrep/Widget/Pager.hs
@@ -15,7 +15,7 @@ module Vgrep.Widget.Pager (
     , replaceBufferContents
     ) where
 
-import           Control.Lens         hiding ((:<), (:>))
+import           Control.Lens.Compat  hiding ((:<), (:>))
 import           Data.Foldable
 import           Data.Sequence        (Seq, (><))
 import qualified Data.Sequence        as Seq

--- a/src/Vgrep/Widget/Pager/Internal.hs
+++ b/src/Vgrep/Widget/Pager/Internal.hs
@@ -12,10 +12,10 @@ module Vgrep.Widget.Pager.Internal (
     , highlighted
     ) where
 
-import Control.Lens
-import Data.Sequence (Seq)
-import Data.Set      (Set)
-import Data.Text     (Text)
+import Control.Lens.Compat
+import Data.Sequence       (Seq)
+import Data.Set            (Set)
+import Data.Text           (Text)
 
 
 -- | Keeps track of the lines of text to display, the current scroll

--- a/src/Vgrep/Widget/Results.hs
+++ b/src/Vgrep/Widget/Results.hs
@@ -27,7 +27,7 @@ module Vgrep.Widget.Results (
     ) where
 
 import           Control.Applicative
-import           Control.Lens
+import           Control.Lens.Compat
 import           Control.Monad.State.Extended
 import           Data.Foldable
 import           Data.Maybe

--- a/src/Vgrep/Widget/Results/Internal.hs
+++ b/src/Vgrep/Widget/Results/Internal.hs
@@ -24,7 +24,7 @@ module Vgrep.Widget.Results.Internal (
     ) where
 
 import           Control.Applicative
-import           Control.Lens        (Getter, pre, to, _Just)
+import           Control.Lens.Compat (Getter, pre, to, _Just)
 import           Data.Foldable
 import           Data.Function
 import           Data.List           (groupBy)

--- a/test/Test/Case.hs
+++ b/test/Test/Case.hs
@@ -19,7 +19,7 @@ module Test.Case (
     , TestTree ()
     ) where
 
-import Control.Lens
+import Control.Lens.Compat
 import Test.QuickCheck.Monadic
 import Test.Tasty
 import Test.Tasty.QuickCheck

--- a/test/Test/Vgrep/Widget/Pager.hs
+++ b/test/Test/Vgrep/Widget/Pager.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 module Test.Vgrep.Widget.Pager (test) where
 
-import           Control.Lens
+import           Control.Lens.Compat
 import qualified Data.Sequence           as S
 import           Data.Text.Testable      ()
 import qualified Data.Text.Testable      as T

--- a/test/Test/Vgrep/Widget/Results.hs
+++ b/test/Test/Vgrep/Widget/Results.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE LambdaCase       #-}
 module Test.Vgrep.Widget.Results (test) where
 
-import           Control.Lens            (Getter, over, to, view, views, _1)
+import           Control.Lens.Compat     (Getter, over, to, view, views, _1)
 import           Data.Map.Strict         ((!))
 import qualified Data.Map.Strict         as Map
 import           Data.Monoid             ((<>))

--- a/vgrep.cabal
+++ b/vgrep.cabal
@@ -35,6 +35,7 @@ library
   default-extensions:  LambdaCase
                      , MultiWayIf
   exposed-Modules:     Control.Concurrent.STM.TPQueue
+                     , Control.Lens.Compat
                      , Control.Monad.State.Extended
                      , Pipes.Concurrent.PQueue
                      , Vgrep.App


### PR DESCRIPTION
Add travis jobs for the newest version of each LTS since `lts-5`. Some fixes were required in order to build and test compatibly over different versions of GHC and different Stackage releases.