### PR TITLE
Migrate away from Vty's DisplayRegion

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -179,7 +179,7 @@ globalEventBindings
 globalEventBindings = \case
     EvResize w h         -> const . Continue $ do
         modifyEnvironment . set viewport $
-            Viewport { _viewportWidth = w, _viewportHeight = h }
+            Viewport { _vpWidth = w, _vpHeight = h }
         pure Redraw
     EvKey (KChar 'q') [] -> const (Interrupt Halt)
     EvKey (KChar 'e') [] -> invokeEditor

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -178,7 +178,8 @@ globalEventBindings
     -> Next (VgrepT AppState m Redraw)
 globalEventBindings = \case
     EvResize w h         -> const . Continue $ do
-        modifyEnvironment (set region (w, h))
+        modifyEnvironment . set viewport $
+            Viewport { _viewportWidth = w, _viewportHeight = h }
         pure Redraw
     EvKey (KChar 'q') [] -> const (Interrupt Halt)
     EvKey (KChar 'e') [] -> invokeEditor

--- a/src/Vgrep/App.hs
+++ b/src/Vgrep/App.hs
@@ -59,14 +59,14 @@ runApp_ app conf externalEvents = void (runApp app conf externalEvents)
 -- 'Vty.Vty' again.
 runApp :: App e s -> Config -> Producer e IO () -> IO s
 runApp app conf externalEvents = withSpawn $ \(evSink, evSource) -> do
-    displayRegion <- displayRegionHack
+    initialViewport <- viewportHack
     let userEventSink   = contramap (User,)   evSink
         systemEventSink = contramap (System,) evSink
     externalEventThread <- (async . runEffect) (externalEvents >-> toOutput systemEventSink)
     initialState <- initialize app
     (_, finalState) <- runVgrepT (appEventLoop app evSource userEventSink)
                                  initialState
-                                 (Env conf displayRegion)
+                                 (Env conf initialViewport)
     cancel externalEventThread
     pure finalState
 

--- a/src/Vgrep/App/Internal.hs
+++ b/src/Vgrep/App/Internal.hs
@@ -19,13 +19,14 @@ import Vgrep.Type
 data EventPriority = User | System deriving (Eq, Ord, Enum)
 
 
--- | We need the display region in order to initialize the app, which in
--- turn will start 'Vty.Vty'. To resolve this circular dependency, we start
--- once 'Vty.Vty' in order to determine the display region, and shut it
--- down again immediately.
-displayRegionHack :: IO DisplayRegion
-displayRegionHack = withVty (Vty.displayBounds . Vty.outputIface)
-
+-- | We need the viewport in order to initialize the app, which in turn will
+-- start 'Vty.Vty'. To resolve this circular dependency, we start once 'Vty.Vty'
+-- in order to determine the display viewport, and shut it down again
+-- immediately.
+viewportHack :: IO Viewport
+viewportHack = withVty $ \vty -> do
+    (width, height) <- Vty.displayBounds (Vty.outputIface vty)
+    pure Viewport { _viewportWidth = width , _viewportHeight = height }
 
 -- | Spawns a thread parallel to the action that listens to 'Vty' events and
 -- redirects them to the 'Consumer'.

--- a/src/Vgrep/App/Internal.hs
+++ b/src/Vgrep/App/Internal.hs
@@ -26,7 +26,7 @@ data EventPriority = User | System deriving (Eq, Ord, Enum)
 viewportHack :: IO Viewport
 viewportHack = withVty $ \vty -> do
     (width, height) <- Vty.displayBounds (Vty.outputIface vty)
-    pure Viewport { _viewportWidth = width , _viewportHeight = height }
+    pure Viewport { _vpWidth = width , _vpHeight = height }
 
 -- | Spawns a thread parallel to the action that listens to 'Vty' events and
 -- redirects them to the 'Consumer'.

--- a/src/Vgrep/Environment.hs
+++ b/src/Vgrep/Environment.hs
@@ -1,29 +1,36 @@
 {-# LANGUAGE TemplateHaskell #-}
 module Vgrep.Environment
     ( Environment (..)
+    , Viewport (..)
 
     -- * Auto-generated Lenses
     , config
-    , region
+    , viewport
+    , viewportWidth
+    , viewportHeight
 
     -- * Re-exports
     , module Vgrep.Environment.Config
-    , module Graphics.Vty.Prelude
     ) where
 
 import Control.Lens.Compat
-import Graphics.Vty.Prelude
 
 import Vgrep.Environment.Config
 
+
+-- | The bounds (width and height) of a display viewport.
+data Viewport = Viewport { _viewportWidth :: Int, _viewportHeight :: Int }
+    deriving (Eq, Show)
+
+makeLenses ''Viewport
 
 -- | 'Vgrep.Type.VgrepT' actions can read from the environment.
 data Environment = Env
     { _config :: Config
     -- ^ External configuration (colors, editor executable, …)
 
-    , _region :: DisplayRegion
-    -- ^ The bounds (width and height) of the display region where the
+    , _viewport :: Viewport
+    -- ^ The bounds (width and height) of the display viewport where the
     -- 'Vgrep.App.App' or the current 'Vgrep.Widget.Widget' is displayed
     } deriving (Eq, Show)
 

--- a/src/Vgrep/Environment.hs
+++ b/src/Vgrep/Environment.hs
@@ -6,6 +6,10 @@ module Vgrep.Environment
     -- * Auto-generated Lenses
     , config
     , viewport
+    , vpHeight
+    , vpWidth
+
+    -- * Convenience Lenses
     , viewportWidth
     , viewportHeight
 
@@ -19,14 +23,15 @@ import Vgrep.Environment.Config
 
 
 -- | The bounds (width and height) of a display viewport.
-data Viewport = Viewport { _viewportWidth :: Int, _viewportHeight :: Int }
+data Viewport = Viewport { _vpWidth :: Int, _vpHeight :: Int }
     deriving (Eq, Show)
 
 makeLenses ''Viewport
 
+
 -- | 'Vgrep.Type.VgrepT' actions can read from the environment.
 data Environment = Env
-    { _config :: Config
+    { _config   :: Config
     -- ^ External configuration (colors, editor executable, …)
 
     , _viewport :: Viewport
@@ -35,3 +40,8 @@ data Environment = Env
     } deriving (Eq, Show)
 
 makeLenses ''Environment
+
+
+viewportHeight, viewportWidth :: Lens' Environment Int
+viewportHeight = viewport . vpHeight
+viewportWidth  = viewport . vpWidth

--- a/src/Vgrep/Widget/HorizontalSplit.hs
+++ b/src/Vgrep/Widget/HorizontalSplit.hs
@@ -22,6 +22,7 @@ module Vgrep.Widget.HorizontalSplit (
     , rightWidgetFocused
     ) where
 
+import Control.Applicative (liftA2)
 import Control.Lens.Compat
 import Data.Monoid
 import Graphics.Vty.Image  hiding (resize)
@@ -45,7 +46,7 @@ type HSplitWidget s t = Widget (HSplit s t)
 -- * __Drawing the Widgets__
 --
 --     Drawing is delegated to the child widgets in a local environment
---     reduced to thir respective 'DisplayRegion'.
+--     reduced to thir respective 'Viewport'.
 --
 -- * __Default keybindings__
 --
@@ -121,7 +122,7 @@ runInLeftWidget
     -> VgrepT s m Image
     -> VgrepT (HSplit s t) m Image
 runInLeftWidget ratio action =
-    let leftRegion = over (region . _1) $ \w ->
+    let leftRegion = over (viewport . viewportWidth) $ \w ->
             ceiling (ratio * fromIntegral w)
     in  zoom leftWidget (local leftRegion action)
 
@@ -132,7 +133,7 @@ runInRightWidget
     -> VgrepT t m Image
     -> VgrepT (HSplit s t) m Image
 runInRightWidget ratio action =
-    let rightRegion = over (region . _1) $ \w ->
+    let rightRegion = over (viewport . viewportWidth) $ \w ->
             floor ((1-ratio) * fromIntegral w)
     in  zoom rightWidget (local rightRegion action)
 
@@ -140,7 +141,7 @@ runInRightWidget ratio action =
 -- Events & Keybindings
 -- ------------------------------------------------------------------------
 
--- FIXME: local region!
+-- FIXME: local viewport!
 handleEvents
     :: Monad m
     => Widget s

--- a/src/Vgrep/Widget/HorizontalSplit.hs
+++ b/src/Vgrep/Widget/HorizontalSplit.hs
@@ -122,7 +122,7 @@ runInLeftWidget
     -> VgrepT s m Image
     -> VgrepT (HSplit s t) m Image
 runInLeftWidget ratio action =
-    let leftRegion = over (viewport . viewportWidth) $ \w ->
+    let leftRegion = over viewportWidth $ \w ->
             ceiling (ratio * fromIntegral w)
     in  zoom leftWidget (local leftRegion action)
 
@@ -133,7 +133,7 @@ runInRightWidget
     -> VgrepT t m Image
     -> VgrepT (HSplit s t) m Image
 runInRightWidget ratio action =
-    let rightRegion = over (viewport . viewportWidth) $ \w ->
+    let rightRegion = over viewportWidth $ \w ->
             floor ((1-ratio) * fromIntegral w)
     in  zoom rightWidget (local rightRegion action)
 

--- a/src/Vgrep/Widget/Pager.hs
+++ b/src/Vgrep/Widget/Pager.hs
@@ -16,17 +16,17 @@ module Vgrep.Widget.Pager (
     , replaceBufferContents
     ) where
 
-import           Control.Lens.Compat  hiding ((:<), (:>))
+import           Control.Applicative (liftA2)
+import           Control.Lens.Compat hiding ((:<), (:>))
 import           Data.Foldable
-import qualified Data.IntMap.Strict   as Map
-import           Data.Monoid          ((<>))
-import           Data.Sequence        (Seq, (><))
-import qualified Data.Sequence        as Seq
-import           Data.Text            (Text)
-import qualified Data.Text            as T
-import           Graphics.Vty.Image   hiding (resize)
+import qualified Data.IntMap.Strict  as Map
+import           Data.Monoid         ((<>))
+import           Data.Sequence       (Seq, (><))
+import qualified Data.Sequence       as Seq
+import           Data.Text           (Text)
+import qualified Data.Text           as T
+import           Graphics.Vty.Image  hiding (resize)
 import           Graphics.Vty.Input
-import           Graphics.Vty.Prelude
 
 import Vgrep.Ansi
 import Vgrep.Environment
@@ -101,7 +101,7 @@ replaceBufferContents newContent newHighlightedLines = put initPager
 
 -- | Scroll to the given line number.
 moveToLine :: Monad m => Int -> VgrepT Pager m Redraw
-moveToLine n = views region regionHeight >>= \height -> do
+moveToLine n = view (viewport . viewportHeight) >>= \height -> do
     setPosition (n - height `div` 2)
     pure Redraw
 
@@ -116,7 +116,7 @@ scroll n = do
     pure Redraw
 
 setPosition :: Monad m => Int -> VgrepT Pager m ()
-setPosition n = views region regionHeight >>= \height -> do
+setPosition n = view (viewport . viewportHeight) >>= \height -> do
     allLines <- liftA2 (+) (uses visible length) (uses above length)
     let newPosition = if
             | n < 0 || allLines < height -> 0
@@ -134,10 +134,9 @@ setPosition n = views region regionHeight >>= \height -> do
 -- > scrollPage (-1)  -- scroll one page up
 -- > scrollPage 1     -- scroll one page down
 scrollPage :: Monad m => Int -> VgrepT Pager m Redraw
-scrollPage n = view region >>= \displayRegion ->
-    let height = regionHeight displayRegion
-    in  scroll (n * (height - 1))
-      -- gracefully leave one ^ line on the screen
+scrollPage n = view (viewport . viewportHeight) >>= \height ->
+    scroll (n * (height - 1))
+  -- gracefully leave one ^ line on the screen
 
 -- | Horizontal scrolling. Increment is one 'tabstop'.
 --
@@ -158,7 +157,8 @@ renderPager = do
     textColorHl       <- view (config . colors . normalHl)
     lineNumberColor   <- view (config . colors . lineNumbers)
     lineNumberColorHl <- view (config . colors . lineNumbersHl)
-    (width, height)   <- view region
+    width             <- view (viewport . viewportWidth)
+    height            <- view (viewport . viewportHeight)
     startPosition     <- use position
     startColumn       <- use (column . to fromIntegral)
     visibleLines      <- use (visible . to (Seq.take height) . to toList)

--- a/src/Vgrep/Widget/Pager.hs
+++ b/src/Vgrep/Widget/Pager.hs
@@ -101,7 +101,7 @@ replaceBufferContents newContent newHighlightedLines = put initPager
 
 -- | Scroll to the given line number.
 moveToLine :: Monad m => Int -> VgrepT Pager m Redraw
-moveToLine n = view (viewport . viewportHeight) >>= \height -> do
+moveToLine n = view viewportHeight >>= \height -> do
     setPosition (n - height `div` 2)
     pure Redraw
 
@@ -116,7 +116,7 @@ scroll n = do
     pure Redraw
 
 setPosition :: Monad m => Int -> VgrepT Pager m ()
-setPosition n = view (viewport . viewportHeight) >>= \height -> do
+setPosition n = view viewportHeight >>= \height -> do
     allLines <- liftA2 (+) (uses visible length) (uses above length)
     let newPosition = if
             | n < 0 || allLines < height -> 0
@@ -134,7 +134,7 @@ setPosition n = view (viewport . viewportHeight) >>= \height -> do
 -- > scrollPage (-1)  -- scroll one page up
 -- > scrollPage 1     -- scroll one page down
 scrollPage :: Monad m => Int -> VgrepT Pager m Redraw
-scrollPage n = view (viewport . viewportHeight) >>= \height ->
+scrollPage n = view viewportHeight >>= \height ->
     scroll (n * (height - 1))
   -- gracefully leave one ^ line on the screen
 
@@ -157,8 +157,8 @@ renderPager = do
     textColorHl       <- view (config . colors . normalHl)
     lineNumberColor   <- view (config . colors . lineNumbers)
     lineNumberColorHl <- view (config . colors . lineNumbersHl)
-    width             <- view (viewport . viewportWidth)
-    height            <- view (viewport . viewportHeight)
+    width             <- view viewportWidth
+    height            <- view viewportHeight
     startPosition     <- use position
     startColumn       <- use (column . to fromIntegral)
     visibleLines      <- use (visible . to (Seq.take height) . to toList)

--- a/src/Vgrep/Widget/Results.hs
+++ b/src/Vgrep/Widget/Results.hs
@@ -36,7 +36,6 @@ import           Data.Text                    (Text)
 import qualified Data.Text                    as T
 import           Graphics.Vty.Image           hiding ((<|>))
 import           Graphics.Vty.Input
-import           Graphics.Vty.Prelude
 import           Prelude
 
 import Vgrep.Ansi
@@ -144,7 +143,7 @@ renderResultList :: Monad m => VgrepT Results m Image
 renderResultList = do
     void resizeToWindow
     visibleLines <- use (to toLines)
-    width <- views region regionWidth
+    width <- view (viewport . viewportWidth)
     let render = renderLine width (lineNumberWidth visibleLines)
     renderedLines <- traverse render visibleLines
     pure (vertCat renderedLines)
@@ -198,7 +197,7 @@ renderLine width lineNumberWidth displayLine = do
 
 resizeToWindow :: Monad m => VgrepT Results m Redraw
 resizeToWindow = do
-    height <- views region regionHeight
+    height <- view (viewport . viewportHeight)
     currentBuffer <- get
     case Internal.resize height currentBuffer of
         Just resizedBuffer -> put resizedBuffer >> pure Redraw

--- a/src/Vgrep/Widget/Results.hs
+++ b/src/Vgrep/Widget/Results.hs
@@ -143,7 +143,7 @@ renderResultList :: Monad m => VgrepT Results m Image
 renderResultList = do
     void resizeToWindow
     visibleLines <- use (to toLines)
-    width <- view (viewport . viewportWidth)
+    width <- view viewportWidth
     let render = renderLine width (lineNumberWidth visibleLines)
     renderedLines <- traverse render visibleLines
     pure (vertCat renderedLines)
@@ -197,7 +197,7 @@ renderLine width lineNumberWidth displayLine = do
 
 resizeToWindow :: Monad m => VgrepT Results m Redraw
 resizeToWindow = do
-    height <- view (viewport . viewportHeight)
+    height <- view viewportHeight
     currentBuffer <- get
     case Internal.resize height currentBuffer of
         Just resizedBuffer -> put resizedBuffer >> pure Redraw

--- a/test/Test/Case.hs
+++ b/test/Test/Case.hs
@@ -20,6 +20,7 @@ module Test.Case (
     ) where
 
 import Control.Lens.Compat
+import Control.Monad
 import Test.QuickCheck.Monadic
 import Test.Tasty
 import Test.Tasty.QuickCheck

--- a/test/Test/Vgrep/Widget/Pager.hs
+++ b/test/Test/Vgrep/Widget/Pager.hs
@@ -2,7 +2,9 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 module Test.Vgrep.Widget.Pager (test) where
 
+import           Control.Applicative
 import           Control.Lens.Compat
+import           Control.Monad
 import qualified Data.Sequence           as S
 import           Data.Text.Testable      ()
 import qualified Data.Text.Testable      as T
@@ -40,7 +42,7 @@ test = runTestCases "Pager widget"
         , assertion = \line -> do
             pos <- use position
             let posOnScreen = line - pos
-            height <- view (region . to regionHeight)
+            height <- view (viewport . viewportHeight)
             pure $ counterexample
                 ("Failed: 0 <= " ++ show posOnScreen ++ " <= " ++ show height)
                 (posOnScreen >= 0 .&&. posOnScreen <= height)
@@ -54,7 +56,7 @@ test = runTestCases "Pager widget"
         , assertion = const $ do
             pos <- use position
             linesVisible <- uses visible length
-            height <- view (region . to regionHeight)
+            height <- view (viewport . viewportHeight)
             pure (pos >= 0 .&&. linesVisible >= height)
         }
     , TestProperty
@@ -76,7 +78,7 @@ emptyPager (pager, _env) = views visible length pager == 0
                         && views above   length pager == 0
 
 coversScreen :: (Pager, Environment) -> Bool
-coversScreen (pager, env) = length (view visible pager) >= view (region . _2) env
+coversScreen (pager, env) = length (view visible pager) >= view (viewport . viewportHeight) env
 
 atTop :: (Pager, Environment) -> Bool
 atTop (pager, _env) = view position pager == 0

--- a/test/Test/Vgrep/Widget/Pager.hs
+++ b/test/Test/Vgrep/Widget/Pager.hs
@@ -42,7 +42,7 @@ test = runTestCases "Pager widget"
         , assertion = \line -> do
             pos <- use position
             let posOnScreen = line - pos
-            height <- view (viewport . viewportHeight)
+            height <- view viewportHeight
             pure $ counterexample
                 ("Failed: 0 <= " ++ show posOnScreen ++ " <= " ++ show height)
                 (posOnScreen >= 0 .&&. posOnScreen <= height)
@@ -56,7 +56,7 @@ test = runTestCases "Pager widget"
         , assertion = const $ do
             pos <- use position
             linesVisible <- uses visible length
-            height <- view (viewport . viewportHeight)
+            height <- view viewportHeight
             pure (pos >= 0 .&&. linesVisible >= height)
         }
     , TestProperty
@@ -78,7 +78,7 @@ emptyPager (pager, _env) = views visible length pager == 0
                         && views above   length pager == 0
 
 coversScreen :: (Pager, Environment) -> Bool
-coversScreen (pager, env) = length (view visible pager) >= view (viewport . viewportHeight) env
+coversScreen (pager, env) = length (view visible pager) >= view viewportHeight env
 
 atTop :: (Pager, Environment) -> Bool
 atTop (pager, _env) = view position pager == 0

--- a/test/Test/Vgrep/Widget/Results.hs
+++ b/test/Test/Vgrep/Widget/Results.hs
@@ -80,7 +80,7 @@ linesBelowCurrent p = \case
     Results _ _ _ ds es -> p (length ds + length es)
 
 screenHeight :: Environment -> Int
-screenHeight = view (viewport . viewportHeight)
+screenHeight = view viewportHeight
 
 moveToLastLineOnScreen :: (Results, Environment) -> (Results, Environment)
 moveToLastLineOnScreen = over _1 $ \case
@@ -114,7 +114,7 @@ assertWidgetFitsOnScreen
     :: (MonadState Results m, MonadReader Environment m)
     => m Property
 assertWidgetFitsOnScreen = do
-    height <- view (viewport . viewportHeight)
+    height <- view viewportHeight
     linesOnScreen <- numberOfLinesOnScreen
     pure $ counterexample
         (show linesOnScreen ++ " > " ++ show height)

--- a/test/Test/Vgrep/Widget/Results.hs
+++ b/test/Test/Vgrep/Widget/Results.hs
@@ -2,7 +2,8 @@
 {-# LANGUAGE LambdaCase       #-}
 module Test.Vgrep.Widget.Results (test) where
 
-import           Control.Lens.Compat     (Getter, over, to, view, views, _1)
+import           Control.Lens.Compat     (Getter, over, to, view, _1)
+import           Control.Monad           (void)
 import           Data.Map.Strict         ((!))
 import qualified Data.Map.Strict         as Map
 import           Data.Monoid             ((<>))
@@ -79,7 +80,7 @@ linesBelowCurrent p = \case
     Results _ _ _ ds es -> p (length ds + length es)
 
 screenHeight :: Environment -> Int
-screenHeight = view (region . to regionHeight)
+screenHeight = view (viewport . viewportHeight)
 
 moveToLastLineOnScreen :: (Results, Environment) -> (Results, Environment)
 moveToLastLineOnScreen = over _1 $ \case
@@ -113,7 +114,7 @@ assertWidgetFitsOnScreen
     :: (MonadState Results m, MonadReader Environment m)
     => m Property
 assertWidgetFitsOnScreen = do
-    height <- views region regionHeight
+    height <- view (viewport . viewportHeight)
     linesOnScreen <- numberOfLinesOnScreen
     pure $ counterexample
         (show linesOnScreen ++ " > " ++ show height)

--- a/test/Vgrep/Environment/Testable.hs
+++ b/test/Vgrep/Environment/Testable.hs
@@ -7,10 +7,11 @@ import Test.QuickCheck
 
 import Vgrep.Environment
 
+
 instance Arbitrary Environment where
     arbitrary = do
         width  <- arbitrary `suchThat` (> 0) -- FIXME tweak numbers
         height <- arbitrary `suchThat` (> 0) -- FIXME tweak numbers
         pure Env
-            { _region = (width, height)
+            { _viewport = Viewport width height
             , _config = defaultConfig }


### PR DESCRIPTION
`DisplayRegion` from Vty is just a pair of `Int`s, with a lot of confusion which one is the width and which one the height. We use our own `Viewport` type, where the semantics are clear from the named record fields.