### PR TITLE
Better tty handling

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -27,7 +27,6 @@ import           System.Directory
 import           System.Environment                 (getArgs)
 import           System.Exit
 import           System.IO
-import           System.Posix.IO
 import           System.Process
 
 import           Vgrep.App                    as App
@@ -227,13 +226,8 @@ invokeEditor state = case views (results . currentFileName) (fmap T.unpack) stat
 
 exec :: MonadIO io => FilePath -> [String] -> io ()
 exec command args = liftIO $ do
-    inHandle  <- fdToHandle =<< ttyIn
-    outHandle <- fdToHandle =<< ttyOut
     (_,_,_,h) <- createProcess $ (proc command args)
-        { std_in  = UseHandle inHandle
-        , std_out = UseHandle outHandle }
-    _ <- waitForProcess h
-    return ()
+    void (waitForProcess h)
 
 ---------------------------------------------------------------------------
 -- Lenses

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -226,7 +226,7 @@ invokeEditor state = case views (results . currentFileName) (fmap T.unpack) stat
 
 exec :: MonadIO io => FilePath -> [String] -> io ()
 exec command args = liftIO $ do
-    (_,_,_,h) <- createProcess $ (proc command args)
+    (_,_,_,h) <- createProcess (proc command args)
     void (waitForProcess h)
 
 ---------------------------------------------------------------------------

--- a/src/Vgrep/App/Internal.hs
+++ b/src/Vgrep/App/Internal.hs
@@ -1,0 +1,70 @@
+{-# LANGUAGE Rank2Types          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections       #-}
+module Vgrep.App.Internal where
+
+import           Control.Concurrent.Async
+import           Control.Exception
+import           Graphics.Vty             (Vty)
+import qualified Graphics.Vty             as Vty
+import           Pipes                    hiding (next)
+import           System.Posix.IO
+import           System.Posix.Types       (Fd)
+
+import Vgrep.Type
+
+
+-- | 'User' events do have higher priority than 'System' events, so that
+-- the application stays responsive even in case of event queue congestion.
+data EventPriority = User | System deriving (Eq, Ord, Enum)
+
+
+-- | We need the display region in order to initialize the app, which in
+-- turn will start 'Vty.Vty'. To resolve this circular dependency, we start
+-- once 'Vty.Vty' in order to determine the display region, and shut it
+-- down again immediately.
+displayRegionHack :: IO DisplayRegion
+displayRegionHack = withVty (Vty.displayBounds . Vty.outputIface)
+
+
+-- | Spawns a thread parallel to the action that listens to 'Vty' events and
+-- redirects them to the 'Consumer'.
+withEvThread :: Consumer Vty.Event IO () -> Vty -> VgrepT s IO a -> VgrepT s IO a
+withEvThread sink vty =
+    vgrepBracket createEvThread cancel . const
+  where
+    createEvThread = (async . runEffect) $ lift (Vty.nextEvent vty) >~ sink
+
+
+-- | Passes a 'Vty' instance to the action and shuts it down properly after the
+-- action finishes. The 'Vty.inputFd' and 'Vty.outputFd' handles are connected
+-- to @/dev/tty@ (see 'tty').
+withVty :: (Vty -> IO a) -> IO a
+-- | Like 'withVty', but lifted to @'VgrepT' s 'IO'@.
+withVgrepVty :: (Vty -> VgrepT s IO a) -> VgrepT s IO a
+(withVty, withVgrepVty) =
+    let initVty fd = do
+            cfg <- Vty.standardIOConfig
+            Vty.mkVty cfg { Vty.inputFd  = Just fd
+                          , Vty.outputFd = Just fd }
+    in  ( \action -> withTty      $ \fd -> bracket      (initVty fd) Vty.shutdown action
+        , \action -> withVgrepTty $ \fd -> vgrepBracket (initVty fd) Vty.shutdown action)
+
+
+-- | Passes two file descriptors for read and write access to @/dev/tty@ to the
+-- action. After the action has finished, the file descriptors will be closed
+-- again.
+withTty :: (Fd -> IO a) -> IO a
+-- | Like 'withTty', but lifted to @'VgrepT' s 'IO'@.
+withVgrepTty :: (Fd -> VgrepT s IO a) -> VgrepT s IO a
+(withTty, withVgrepTty) = (bracket before after, vgrepBracket before after)
+  where
+    before = tty
+    after fd = closeFd fd `catch` ignoreIOException
+    ignoreIOException :: IOException -> IO ()
+    ignoreIOException _ = pure ()
+
+-- | Opens @/dev/tty@ in Read/Write mode. Should be connected to the @stdin@ and
+-- @stdout@ of a GUI process (e. g. 'Vty.Vty').
+tty :: IO Fd
+tty = openFd "/dev/tty" ReadWrite Nothing defaultFileFlags

--- a/src/Vgrep/App/Internal.hs
+++ b/src/Vgrep/App/Internal.hs
@@ -38,7 +38,7 @@ withEvThread sink vty =
 
 -- | Passes a 'Vty' instance to the action and shuts it down properly after the
 -- action finishes. The 'Vty.inputFd' and 'Vty.outputFd' handles are connected
--- to @/dev/tty@ (see 'tty').
+-- to @\/dev\/tty@ (see 'tty').
 withVty :: (Vty -> IO a) -> IO a
 -- | Like 'withVty', but lifted to @'VgrepT' s 'IO'@.
 withVgrepVty :: (Vty -> VgrepT s IO a) -> VgrepT s IO a
@@ -51,9 +51,8 @@ withVgrepVty :: (Vty -> VgrepT s IO a) -> VgrepT s IO a
         , \action -> withVgrepTty $ \fd -> vgrepBracket (initVty fd) Vty.shutdown action)
 
 
--- | Passes two file descriptors for read and write access to @/dev/tty@ to the
--- action. After the action has finished, the file descriptors will be closed
--- again.
+-- | Passes two file descriptors for read and write access to @\/dev\/tty@ to
+-- the action, and closes them after the action has finished.
 withTty :: (Fd -> IO a) -> IO a
 -- | Like 'withTty', but lifted to @'VgrepT' s 'IO'@.
 withVgrepTty :: (Fd -> VgrepT s IO a) -> VgrepT s IO a
@@ -64,7 +63,7 @@ withVgrepTty :: (Fd -> VgrepT s IO a) -> VgrepT s IO a
     ignoreIOException :: IOException -> IO ()
     ignoreIOException _ = pure ()
 
--- | Opens @/dev/tty@ in Read/Write mode. Should be connected to the @stdin@ and
+-- | Opens @\/dev\/tty@ in Read/Write mode. Should be connected to the @stdin@ and
 -- @stdout@ of a GUI process (e. g. 'Vty.Vty').
 tty :: IO Fd
 tty = openFd "/dev/tty" ReadWrite Nothing defaultFileFlags

--- a/vgrep.cabal
+++ b/vgrep.cabal
@@ -104,7 +104,6 @@ executable vgrep
                      , process            >= 1.2.3
                      , template-haskell   >= 2.10
                      , text               >= 1.2.1.3
-                     , unix               >= 2.7.1
                      , vgrep
                      , vty                >= 5.4.0
   default-language:    Haskell2010

--- a/vgrep.cabal
+++ b/vgrep.cabal
@@ -43,6 +43,7 @@ library
                      , Vgrep.Ansi.Type
                      , Vgrep.Ansi.Vty.Attributes
                      , Vgrep.App
+                     , Vgrep.App.Internal
                      , Vgrep.Environment
                      , Vgrep.Environment.Config
                      , Vgrep.Environment.Config.Monoid


### PR DESCRIPTION
Some simplifications and abstractions concerning the allocation of TTY file descriptors:
* Instead of creating one file descriptor for reading and one for writing, one with read an write access is sufficient.
* The file descriptor should be closed safely when the tty is handed over to another application (e.g. editor)
* Some housekeeping.