### PR TITLE
Switch to aeson >= 1

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,18 +1,14 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-5.0
+resolver: nightly-2017-01-13
 
 # Local packages, usually specified by relative directory name
 packages:
 - '.'
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-extra-deps:
-  # We want a recent version of stylish-haskell.
-  # This is olny for tooling, so does not affect
-  # dependency management.
-  - stylish-haskell-0.6.1.0
+extra-deps: []
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/vgrep.cabal
+++ b/vgrep.cabal
@@ -69,7 +69,7 @@ library
                      , Vgrep.Widget.Results.Internal
                      , Vgrep.Widget.Type
   build-depends:       base >= 4.7 && < 5
-                     , aeson              >= 0.11 || (>= 0.9 && < 0.10)
+                     , aeson              >= 1.0.0.0
                      , async              >= 2.0.2
                      , attoparsec         >= 0.12.1.6
                      , containers         >= 0.5.6.2


### PR DESCRIPTION
With this change, the error message for a bad key chord in the config
file changes slightly:

Original error message:

    Could not parse config file /home/simon/.vgrep/config.yaml:
    Aeson exception:
    Error in $.keybindings['results-keybindings']: failed to parse field keybindings: failed to parse field results-keybindings: Unknown key 'bad-chord'
    Falling back to default config.

New error message:

    Could not parse config file /home/simon/.vgrep/config.yaml:
    Aeson exception:
    Error in $.keybindings['results-keybindings']['bad-chord']: Unknown key 'bad-chord'
    Falling back to default config.